### PR TITLE
remove unused fields

### DIFF
--- a/openapi-generator/src/main/resources/fullstory-typescript/model.mustache
+++ b/openapi-generator/src/main/resources/fullstory-typescript/model.mustache
@@ -23,33 +23,6 @@ export class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
 {{/description}}
     '{{name}}'{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}}{{#defaultValue}} = {{#isEnum}}{{classname}}.{{/isEnum}}{{{.}}}{{/defaultValue}};
 {{/vars}}
-
-    {{#discriminator}}
-    static discriminator: string | undefined = '{{discriminatorName}}';
-    {{/discriminator}}
-    {{^discriminator}}
-    static discriminator: string | undefined = undefined;
-    {{/discriminator}}
-
-    {{^isArray}}
-    static attributeTypeMap: Array<{ name: string, baseName: string, type: string; }> = [
-        {{#vars}}{
-            'name': '{{name}}',
-            'baseName': '{{baseName}}',
-            'type': '{{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}'
-        }{{^-last}},
-        {{/-last}}{{/vars}}
-    ];
-
-    static getAttributeTypeMap() {
-        {{#parent}}
-        return super.getAttributeTypeMap().concat({{classname}}.attributeTypeMap);
-        {{/parent}}
-        {{^parent}}
-        return {{classname}}.attributeTypeMap;
-        {{/parent}}
-    }
-    {{/isArray}}
 }
 
 {{#hasEnums}}

--- a/src/model/apierror/ErrorResponse.ts
+++ b/src/model/apierror/ErrorResponse.ts
@@ -14,24 +14,5 @@ export class ErrorResponse {
     * A short snake-cased value that is safe to handle programmatically
     */
     'code'?: string = undefined;
-
-    static discriminator: string | undefined = undefined;
-
-    static attributeTypeMap: Array<{ name: string, baseName: string, type: string; }> = [
-        {
-            'name': 'message',
-            'baseName': 'message',
-            'type': 'string'
-        },
-        {
-            'name': 'code',
-            'baseName': 'code',
-            'type': 'string'
-        }
-    ];
-
-    static getAttributeTypeMap() {
-        return ErrorResponse.attributeTypeMap;
-    }
 }
 

--- a/src/model/job/JobMetadata.ts
+++ b/src/model/job/JobMetadata.ts
@@ -23,34 +23,5 @@ export class JobMetadata {
     * Time the job was finished, either successfully or unsuccessfully.
     */
     'finished'?: string = undefined;
-
-    static discriminator: string | undefined = undefined;
-
-    static attributeTypeMap: Array<{ name: string, baseName: string, type: string; }> = [
-        {
-            'name': 'id',
-            'baseName': 'id',
-            'type': 'string'
-        },
-        {
-            'name': 'status',
-            'baseName': 'status',
-            'type': 'JobStatus'
-        },
-        {
-            'name': 'created',
-            'baseName': 'created',
-            'type': 'string'
-        },
-        {
-            'name': 'finished',
-            'baseName': 'finished',
-            'type': 'string'
-        }
-    ];
-
-    static getAttributeTypeMap() {
-        return JobMetadata.attributeTypeMap;
-    }
 }
 

--- a/src/model/users/BatchUserImportRequest.ts
+++ b/src/model/users/BatchUserImportRequest.ts
@@ -26,39 +26,5 @@ export class BatchUserImportRequest {
     * Properties that provide additional information about your user. * Up to 500 unique properties are allowed. * Property names must be a sequence of alphanumeric characters A-Z, a-z, or 0-9 and underscores (\"_\"). * Property names must start with an alphabetic character (A-Z or a-z). * The maximum property name length is 512 characters. * Property values may also contain nested objects. Properties within nested objects must still conform to the naming requirements. For nested objects, the property name including the dotted concatenation of all its parent properties must still be under the length limit of 512 characters. * Property values have a maximum size of 8192 bytes. If the value for the property is larger than this limit, the property will be rejected.
     */
     'properties'?: object = undefined;
-
-    static discriminator: string | undefined = undefined;
-
-    static attributeTypeMap: Array<{ name: string, baseName: string, type: string; }> = [
-        {
-            'name': 'id',
-            'baseName': 'id',
-            'type': 'string'
-        },
-        {
-            'name': 'uid',
-            'baseName': 'uid',
-            'type': 'string'
-        },
-        {
-            'name': 'display_name',
-            'baseName': 'display_name',
-            'type': 'string'
-        },
-        {
-            'name': 'email',
-            'baseName': 'email',
-            'type': 'string'
-        },
-        {
-            'name': 'properties',
-            'baseName': 'properties',
-            'type': 'object'
-        }
-    ];
-
-    static getAttributeTypeMap() {
-        return BatchUserImportRequest.attributeTypeMap;
-    }
 }
 

--- a/src/model/users/BatchUserImportResponse.ts
+++ b/src/model/users/BatchUserImportResponse.ts
@@ -26,39 +26,5 @@ export class BatchUserImportResponse {
     * Properties that provide additional information about your user. * Up to 500 unique properties are allowed. * Property names must be a sequence of alphanumeric characters A-Z, a-z, or 0-9 and underscores (\"_\"). * Property names must start with an alphabetic character (A-Z or a-z). * The maximum property name length is 512 characters. * Property values may also contain nested objects. Properties within nested objects must still conform to the naming requirements. For nested objects, the property name including the dotted concatenation of all its parent properties must still be under the length limit of 512 characters. * Property values have a maximum size of 8192 bytes. If the value for the property is larger than this limit, the property will be rejected.
     */
     'properties'?: object = undefined;
-
-    static discriminator: string | undefined = undefined;
-
-    static attributeTypeMap: Array<{ name: string, baseName: string, type: string; }> = [
-        {
-            'name': 'id',
-            'baseName': 'id',
-            'type': 'string'
-        },
-        {
-            'name': 'uid',
-            'baseName': 'uid',
-            'type': 'string'
-        },
-        {
-            'name': 'display_name',
-            'baseName': 'display_name',
-            'type': 'string'
-        },
-        {
-            'name': 'email',
-            'baseName': 'email',
-            'type': 'string'
-        },
-        {
-            'name': 'properties',
-            'baseName': 'properties',
-            'type': 'object'
-        }
-    ];
-
-    static getAttributeTypeMap() {
-        return BatchUserImportResponse.attributeTypeMap;
-    }
 }
 

--- a/src/model/users/CreateBatchUserImportJobRequest.ts
+++ b/src/model/users/CreateBatchUserImportJobRequest.ts
@@ -11,19 +11,5 @@ export class CreateBatchUserImportJobRequest {
     * The list of users and their information that should be imported in this batch request
     */
     'requests'?: Array<BatchUserImportRequest> = undefined;
-
-    static discriminator: string | undefined = undefined;
-
-    static attributeTypeMap: Array<{ name: string, baseName: string, type: string; }> = [
-        {
-            'name': 'requests',
-            'baseName': 'requests',
-            'type': 'Array<BatchUserImportRequest>'
-        }
-    ];
-
-    static getAttributeTypeMap() {
-        return CreateBatchUserImportJobRequest.attributeTypeMap;
-    }
 }
 

--- a/src/model/users/CreateBatchUserImportJobResponse.ts
+++ b/src/model/users/CreateBatchUserImportJobResponse.ts
@@ -8,19 +8,5 @@ import { JobMetadata } from '@model/job/JobMetadata';
 
 export class CreateBatchUserImportJobResponse {
     'job'?: JobMetadata = undefined;
-
-    static discriminator: string | undefined = undefined;
-
-    static attributeTypeMap: Array<{ name: string, baseName: string, type: string; }> = [
-        {
-            'name': 'job',
-            'baseName': 'job',
-            'type': 'JobMetadata'
-        }
-    ];
-
-    static getAttributeTypeMap() {
-        return CreateBatchUserImportJobResponse.attributeTypeMap;
-    }
 }
 

--- a/src/model/users/CreateUserRequest.ts
+++ b/src/model/users/CreateUserRequest.ts
@@ -22,34 +22,5 @@ export class CreateUserRequest {
     * Properties that provide additional information about your user. * Up to 500 unique properties are allowed. * Property names must be a sequence of alphanumeric characters A-Z, a-z, or 0-9 and underscores (\"_\"). * Property names must start with an alphabetic character (A-Z or a-z). * The maximum property name length is 512 characters. * Property values may also contain nested objects. Properties within nested objects must still conform to the naming requirements. For nested objects, the property name including the dotted concatenation of all its parent properties must still be under the length limit of 512 characters. * Property values have a maximum size of 8192 bytes. If the value for the property is larger than this limit, the property will be rejected.
     */
     'properties'?: object = undefined;
-
-    static discriminator: string | undefined = undefined;
-
-    static attributeTypeMap: Array<{ name: string, baseName: string, type: string; }> = [
-        {
-            'name': 'uid',
-            'baseName': 'uid',
-            'type': 'string'
-        },
-        {
-            'name': 'display_name',
-            'baseName': 'display_name',
-            'type': 'string'
-        },
-        {
-            'name': 'email',
-            'baseName': 'email',
-            'type': 'string'
-        },
-        {
-            'name': 'properties',
-            'baseName': 'properties',
-            'type': 'object'
-        }
-    ];
-
-    static getAttributeTypeMap() {
-        return CreateUserRequest.attributeTypeMap;
-    }
 }
 

--- a/src/model/users/CreateUserResponse.ts
+++ b/src/model/users/CreateUserResponse.ts
@@ -26,39 +26,5 @@ export class CreateUserResponse {
     * Properties that provide additional information about your user. * Up to 500 unique properties are allowed. * Property names must be a sequence of alphanumeric characters A-Z, a-z, or 0-9 and underscores (\"_\"). * Property names must start with an alphabetic character (A-Z or a-z). * The maximum property name length is 512 characters. * Property values may also contain nested objects. Properties within nested objects must still conform to the naming requirements. For nested objects, the property name including the dotted concatenation of all its parent properties must still be under the length limit of 512 characters. * Property values have a maximum size of 8192 bytes. If the value for the property is larger than this limit, the property will be rejected.
     */
     'properties'?: object = undefined;
-
-    static discriminator: string | undefined = undefined;
-
-    static attributeTypeMap: Array<{ name: string, baseName: string, type: string; }> = [
-        {
-            'name': 'id',
-            'baseName': 'id',
-            'type': 'string'
-        },
-        {
-            'name': 'uid',
-            'baseName': 'uid',
-            'type': 'string'
-        },
-        {
-            'name': 'display_name',
-            'baseName': 'display_name',
-            'type': 'string'
-        },
-        {
-            'name': 'email',
-            'baseName': 'email',
-            'type': 'string'
-        },
-        {
-            'name': 'properties',
-            'baseName': 'properties',
-            'type': 'object'
-        }
-    ];
-
-    static getAttributeTypeMap() {
-        return CreateUserResponse.attributeTypeMap;
-    }
 }
 

--- a/src/model/users/FailedUserImport.ts
+++ b/src/model/users/FailedUserImport.ts
@@ -16,29 +16,5 @@ export class FailedUserImport {
     */
     'code'?: string = undefined;
     'user'?: BatchUserImportRequest = undefined;
-
-    static discriminator: string | undefined = undefined;
-
-    static attributeTypeMap: Array<{ name: string, baseName: string, type: string; }> = [
-        {
-            'name': 'message',
-            'baseName': 'message',
-            'type': 'string'
-        },
-        {
-            'name': 'code',
-            'baseName': 'code',
-            'type': 'string'
-        },
-        {
-            'name': 'user',
-            'baseName': 'user',
-            'type': 'BatchUserImportRequest'
-        }
-    ];
-
-    static getAttributeTypeMap() {
-        return FailedUserImport.attributeTypeMap;
-    }
 }
 

--- a/src/model/users/GetBatchUserImportErrorsResponse.ts
+++ b/src/model/users/GetBatchUserImportErrorsResponse.ts
@@ -19,29 +19,5 @@ export class GetBatchUserImportErrorsResponse {
     * The token that can be used in a subsequent request to fetch the next page of import failures
     */
     'next_page_token'?: string = undefined;
-
-    static discriminator: string | undefined = undefined;
-
-    static attributeTypeMap: Array<{ name: string, baseName: string, type: string; }> = [
-        {
-            'name': 'results',
-            'baseName': 'results',
-            'type': 'Array<FailedUserImport>'
-        },
-        {
-            'name': 'total_records',
-            'baseName': 'total_records',
-            'type': 'string'
-        },
-        {
-            'name': 'next_page_token',
-            'baseName': 'next_page_token',
-            'type': 'string'
-        }
-    ];
-
-    static getAttributeTypeMap() {
-        return GetBatchUserImportErrorsResponse.attributeTypeMap;
-    }
 }
 

--- a/src/model/users/GetBatchUserImportStatusResponse.ts
+++ b/src/model/users/GetBatchUserImportStatusResponse.ts
@@ -16,29 +16,5 @@ export class GetBatchUserImportStatusResponse {
     */
     'errors'?: string = undefined;
     'job'?: JobMetadata = undefined;
-
-    static discriminator: string | undefined = undefined;
-
-    static attributeTypeMap: Array<{ name: string, baseName: string, type: string; }> = [
-        {
-            'name': 'imports',
-            'baseName': 'imports',
-            'type': 'string'
-        },
-        {
-            'name': 'errors',
-            'baseName': 'errors',
-            'type': 'string'
-        },
-        {
-            'name': 'job',
-            'baseName': 'job',
-            'type': 'JobMetadata'
-        }
-    ];
-
-    static getAttributeTypeMap() {
-        return GetBatchUserImportStatusResponse.attributeTypeMap;
-    }
 }
 

--- a/src/model/users/GetBatchUserImportsResponse.ts
+++ b/src/model/users/GetBatchUserImportsResponse.ts
@@ -19,29 +19,5 @@ export class GetBatchUserImportsResponse {
     * The token that can be used in a subsequent request to fetch the next page of import results
     */
     'next_page_token'?: string = undefined;
-
-    static discriminator: string | undefined = undefined;
-
-    static attributeTypeMap: Array<{ name: string, baseName: string, type: string; }> = [
-        {
-            'name': 'results',
-            'baseName': 'results',
-            'type': 'Array<BatchUserImportResponse>'
-        },
-        {
-            'name': 'total_records',
-            'baseName': 'total_records',
-            'type': 'string'
-        },
-        {
-            'name': 'next_page_token',
-            'baseName': 'next_page_token',
-            'type': 'string'
-        }
-    ];
-
-    static getAttributeTypeMap() {
-        return GetBatchUserImportsResponse.attributeTypeMap;
-    }
 }
 

--- a/src/model/users/GetUserResponse.ts
+++ b/src/model/users/GetUserResponse.ts
@@ -30,44 +30,5 @@ export class GetUserResponse {
     * Properties that provide additional information about your user. * Up to 500 unique properties are allowed. * Property names must be a sequence of alphanumeric characters A-Z, a-z, or 0-9 and underscores (\"_\"). * Property names must start with an alphabetic character (A-Z or a-z). * The maximum property name length is 512 characters. * Property values may also contain nested objects. Properties within nested objects must still conform to the naming requirements. For nested objects, the property name including the dotted concatenation of all its parent properties must still be under the length limit of 512 characters. * Property values have a maximum size of 8192 bytes. If the value for the property is larger than this limit, the property will be rejected.
     */
     'properties'?: object = undefined;
-
-    static discriminator: string | undefined = undefined;
-
-    static attributeTypeMap: Array<{ name: string, baseName: string, type: string; }> = [
-        {
-            'name': 'id',
-            'baseName': 'id',
-            'type': 'string'
-        },
-        {
-            'name': 'uid',
-            'baseName': 'uid',
-            'type': 'string'
-        },
-        {
-            'name': 'display_name',
-            'baseName': 'display_name',
-            'type': 'string'
-        },
-        {
-            'name': 'email',
-            'baseName': 'email',
-            'type': 'string'
-        },
-        {
-            'name': 'is_being_deleted',
-            'baseName': 'is_being_deleted',
-            'type': 'boolean'
-        },
-        {
-            'name': 'properties',
-            'baseName': 'properties',
-            'type': 'object'
-        }
-    ];
-
-    static getAttributeTypeMap() {
-        return GetUserResponse.attributeTypeMap;
-    }
 }
 

--- a/src/model/users/ListUsersResponse.ts
+++ b/src/model/users/ListUsersResponse.ts
@@ -19,29 +19,5 @@ export class ListUsersResponse {
     * The token that can be used in a subsequent request with the same filter criteria to fetch the next page of users
     */
     'next_page_token'?: string = undefined;
-
-    static discriminator: string | undefined = undefined;
-
-    static attributeTypeMap: Array<{ name: string, baseName: string, type: string; }> = [
-        {
-            'name': 'results',
-            'baseName': 'results',
-            'type': 'Array<GetUserResponse>'
-        },
-        {
-            'name': 'total_records',
-            'baseName': 'total_records',
-            'type': 'string'
-        },
-        {
-            'name': 'next_page_token',
-            'baseName': 'next_page_token',
-            'type': 'string'
-        }
-    ];
-
-    static getAttributeTypeMap() {
-        return ListUsersResponse.attributeTypeMap;
-    }
 }
 

--- a/src/model/users/UpdateUserRequest.ts
+++ b/src/model/users/UpdateUserRequest.ts
@@ -22,34 +22,5 @@ export class UpdateUserRequest {
     * Properties that provide additional information about your user. * Up to 500 unique properties are allowed. * Property names must be a sequence of alphanumeric characters A-Z, a-z, or 0-9 and underscores (\"_\"). * Property names must start with an alphabetic character (A-Z or a-z). * The maximum property name length is 512 characters. * Property values may also contain nested objects. Properties within nested objects must still conform to the naming requirements. For nested objects, the property name including the dotted concatenation of all its parent properties must still be under the length limit of 512 characters. * Property values have a maximum size of 8192 bytes. If the value for the property is larger than this limit, the property will be rejected.
     */
     'properties'?: object = undefined;
-
-    static discriminator: string | undefined = undefined;
-
-    static attributeTypeMap: Array<{ name: string, baseName: string, type: string; }> = [
-        {
-            'name': 'uid',
-            'baseName': 'uid',
-            'type': 'string'
-        },
-        {
-            'name': 'display_name',
-            'baseName': 'display_name',
-            'type': 'string'
-        },
-        {
-            'name': 'email',
-            'baseName': 'email',
-            'type': 'string'
-        },
-        {
-            'name': 'properties',
-            'baseName': 'properties',
-            'type': 'object'
-        }
-    ];
-
-    static getAttributeTypeMap() {
-        return UpdateUserRequest.attributeTypeMap;
-    }
 }
 

--- a/src/model/users/UpdateUserResponse.ts
+++ b/src/model/users/UpdateUserResponse.ts
@@ -26,39 +26,5 @@ export class UpdateUserResponse {
     * Properties that provide additional information about your user. * Up to 500 unique properties are allowed. * Property names must be a sequence of alphanumeric characters A-Z, a-z, or 0-9 and underscores (\"_\"). * Property names must start with an alphabetic character (A-Z or a-z). * The maximum property name length is 512 characters. * Property values may also contain nested objects. Properties within nested objects must still conform to the naming requirements. For nested objects, the property name including the dotted concatenation of all its parent properties must still be under the length limit of 512 characters. * Property values have a maximum size of 8192 bytes. If the value for the property is larger than this limit, the property will be rejected.
     */
     'properties'?: object = undefined;
-
-    static discriminator: string | undefined = undefined;
-
-    static attributeTypeMap: Array<{ name: string, baseName: string, type: string; }> = [
-        {
-            'name': 'id',
-            'baseName': 'id',
-            'type': 'string'
-        },
-        {
-            'name': 'uid',
-            'baseName': 'uid',
-            'type': 'string'
-        },
-        {
-            'name': 'display_name',
-            'baseName': 'display_name',
-            'type': 'string'
-        },
-        {
-            'name': 'email',
-            'baseName': 'email',
-            'type': 'string'
-        },
-        {
-            'name': 'properties',
-            'baseName': 'properties',
-            'type': 'object'
-        }
-    ];
-
-    static getAttributeTypeMap() {
-        return UpdateUserResponse.attributeTypeMap;
-    }
 }
 


### PR DESCRIPTION
I don't think we need the attribute map that was originally used to serialize objects. Theres more work to be done on parsing models, but these aren't needed