### PR TITLE
better mock http client

### DIFF
--- a/openapi-generator/src/main/resources/fullstory-typescript/api-single.mustache
+++ b/openapi-generator/src/main/resources/fullstory-typescript/api-single.mustache
@@ -15,7 +15,7 @@ import { {{key}} } from '@model/{{value}}';
 {{/entrySet}}
 {{/tsImports}}
 
-import { FSHttpClient, FSRequestOptions, FSResponse, FullStoryOptions } from '../../http';
+import { FSHttpClient, FSRequestOptions, FSResponse, FullStoryOptions, IFSHttpClient, rethrowChainedError } from '../../http';
 {{#operations}}
 {{#description}}
 
@@ -25,7 +25,7 @@ import { FSHttpClient, FSRequestOptions, FSResponse, FullStoryOptions } from '..
 {{/description}}
 export class {{classname}} {
     protected readonly basePath = '{{{basePath}}}';
-    protected readonly httpClient: FSHttpClient;
+    private httpClient: IFSHttpClient;
 
     constructor(opts: FullStoryOptions) {
         // TODO(sabrina): allow injecting http client dependency rather than instantiating here
@@ -84,7 +84,7 @@ export class {{classname}} {
         try {
             return await this.httpClient.request<{{#bodyParam}}{{dataType}}{{/bodyParam}}{{^bodyParam}}void{{/bodyParam}}, {{#returnType}}{{{.}}}{{/returnType}}{{^returnType}}void{{/returnType}}>(requestOptions{{#bodyParam}}, body{{/bodyParam}}{{^bodyParam}}, undefined{{/bodyParam}}, options);
         } catch (e) {
-            rethrowChainedError(e)
+            rethrowChainedError(e);
         }
         {{! TODO(Sabrina): Check for AuthMethods.
         server APIs only support api key auth at the moment, no need to optimize prematurely atm. }}

--- a/src/__tests__/users.smoke.test.ts
+++ b/src/__tests__/users.smoke.test.ts
@@ -135,8 +135,8 @@ describe('FullStory Users API', () => {
         job.on('processing', (job) => {
             expect(job.getId()).toBeTruthy();
             expect(job.metadata?.status).toBe(JobStatus.Processing);
-            expect(job.getImports()).toBeUndefined();
-            expect(job.getImportErrors()).toBeUndefined();
+            expect(job.getImports()).toEqual([]);
+            expect(job.getImportErrors()).toEqual([]);
         });
 
         job.on('done',

--- a/src/api/users/UsersApi.ts
+++ b/src/api/users/UsersApi.ts
@@ -18,10 +18,10 @@ import { CreateUserRequest } from '@model/users/CreateUserRequest';
 import { UpdateUserRequest } from '@model/users/UpdateUserRequest';
 import { ErrorResponse } from '@model/apierror/ErrorResponse';
 
-import { FSHttpClient, FSRequestOptions, FSResponse, FullStoryOptions } from '../../http';
+import { FSHttpClient, FSRequestOptions, FSResponse, FullStoryOptions, IFSHttpClient, rethrowChainedError } from '../../http';
 export class UsersApi {
     protected readonly basePath = 'https://api.fullstory.com';
-    protected readonly httpClient: FSHttpClient;
+    private httpClient: IFSHttpClient;
 
     constructor(opts: FullStoryOptions) {
         // TODO(sabrina): allow injecting http client dependency rather than instantiating here
@@ -59,7 +59,7 @@ export class UsersApi {
         try {
             return await this.httpClient.request<CreateUserRequest, CreateUserResponse>(requestOptions, body, options);
         } catch (e) {
-            rethrowChainedError(e)
+            rethrowChainedError(e);
         }
     }
 
@@ -87,7 +87,7 @@ export class UsersApi {
         try {
             return await this.httpClient.request<void, void>(requestOptions, undefined, options);
         } catch (e) {
-            rethrowChainedError(e)
+            rethrowChainedError(e);
         }
     }
 
@@ -115,7 +115,7 @@ export class UsersApi {
         try {
             return await this.httpClient.request<void, GetUserResponse>(requestOptions, undefined, options);
         } catch (e) {
-            rethrowChainedError(e)
+            rethrowChainedError(e);
         }
     }
 
@@ -161,7 +161,7 @@ export class UsersApi {
         try {
             return await this.httpClient.request<void, ListUsersResponse>(requestOptions, undefined, options);
         } catch (e) {
-            rethrowChainedError(e)
+            rethrowChainedError(e);
         }
     }
 
@@ -198,7 +198,7 @@ export class UsersApi {
         try {
             return await this.httpClient.request<UpdateUserRequest, UpdateUserResponse>(requestOptions, body, options);
         } catch (e) {
-            rethrowChainedError(e)
+            rethrowChainedError(e);
         }
     }
 }

--- a/src/api/users/UsersBatchImportApi.ts
+++ b/src/api/users/UsersBatchImportApi.ts
@@ -17,10 +17,10 @@ import { CreateBatchUserImportJobResponse } from '@model/users/CreateBatchUserIm
 import { GetBatchUserImportStatusResponse } from '@model/users/GetBatchUserImportStatusResponse';
 import { ErrorResponse } from '@model/apierror/ErrorResponse';
 
-import { FSHttpClient, FSRequestOptions, FSResponse, FullStoryOptions } from '../../http';
+import { FSHttpClient, FSRequestOptions, FSResponse, FullStoryOptions, IFSHttpClient, rethrowChainedError } from '../../http';
 export class UsersBatchImportApi {
     protected readonly basePath = 'https://api.fullstory.com';
-    protected readonly httpClient: FSHttpClient;
+    private httpClient: IFSHttpClient;
 
     constructor(opts: FullStoryOptions) {
         // TODO(sabrina): allow injecting http client dependency rather than instantiating here
@@ -58,7 +58,7 @@ export class UsersBatchImportApi {
         try {
             return await this.httpClient.request<CreateBatchUserImportJobRequest, CreateBatchUserImportJobResponse>(requestOptions, body, options);
         } catch (e) {
-            rethrowChainedError(e)
+            rethrowChainedError(e);
         }
     }
 
@@ -90,7 +90,7 @@ export class UsersBatchImportApi {
         try {
             return await this.httpClient.request<void, GetBatchUserImportErrorsResponse>(requestOptions, undefined, options);
         } catch (e) {
-            rethrowChainedError(e)
+            rethrowChainedError(e);
         }
     }
 
@@ -118,7 +118,7 @@ export class UsersBatchImportApi {
         try {
             return await this.httpClient.request<void, GetBatchUserImportStatusResponse>(requestOptions, undefined, options);
         } catch (e) {
-            rethrowChainedError(e)
+            rethrowChainedError(e);
         }
     }
 
@@ -150,7 +150,7 @@ export class UsersBatchImportApi {
         try {
             return await this.httpClient.request<void, GetBatchUserImportsResponse>(requestOptions, undefined, options);
         } catch (e) {
-            rethrowChainedError(e)
+            rethrowChainedError(e);
         }
     }
 }


### PR DESCRIPTION
use jest manual mock for the http client a class so we can isolate the mocked states between different test files (once events apis are added)
~DO NOT MERGE UNTIL #9~