### PR TITLE
prefix api key with 'basic'

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -10,9 +10,17 @@ describe('FullStory SDK', () => {
             apiKey: MOCK_API_KEY,
         });
         expect(client).toHaveProperty('opts');
-        expect((client as any)['opts']).toHaveProperty('apiKey', MOCK_API_KEY);
+        expect((client as any)['opts']).toHaveProperty('apiKey', 'Basic ' + MOCK_API_KEY);
 
         expect(client).toHaveProperty('users');
         expect(client).toHaveProperty('events');
+    });
+
+    test('can initialize with prefixed api key', () => {
+        const client = init({
+            apiKey: 'Basic ' + MOCK_API_KEY,
+        });
+        expect(client).toHaveProperty('opts');
+        expect((client as any)['opts']).toHaveProperty('apiKey', 'Basic ' + MOCK_API_KEY);
     });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,13 @@
+import { FSUnknownError } from './errors';
 import { FullStoryClient, FullStoryImpl } from './fullstory';
 import { FullStoryOptions } from './http';
 
 export function init(opts: FullStoryOptions): FullStoryClient {
-    return new FullStoryImpl(opts);
+    if (!opts.apiKey) {
+        throw new FSUnknownError('apiKey is required in opts');
+    }
+    const apiKey = opts.apiKey.indexOf(' ') < 0 ? `Basic ${opts.apiKey}` : opts.apiKey;
+    return new FullStoryImpl({ ...opts, apiKey });
 }
 
 export * from '@api/index';


### PR DESCRIPTION
allow passing in a bare api key without "Besic"