### PR TITLE
add integration source if provided

### DIFF
--- a/src/__tests__/events.smoke.test.ts
+++ b/src/__tests__/events.smoke.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from '@jest/globals';
 import { CreateEventsRequest, JobStatus } from '@model/index';
+import { create } from 'domain';
 import * as dotenv from 'dotenv';
 
 import { Events } from '../events';
@@ -8,6 +9,7 @@ dotenv.config();
 const { RUN_SMOKE_TESTS, FS_API_KEY } = process.env;
 
 const BATCH_JOB_TIMEOUT = 10000; // wait for 10 seconds for the job to finish
+const INTEGRATION_SRC = 'NodeJS SDK Smoke Test';
 
 describe('FullStory Events API', () => {
     if (!RUN_SMOKE_TESTS || !FS_API_KEY) {
@@ -17,6 +19,7 @@ describe('FullStory Events API', () => {
 
     const events = new Events({
         apiKey: `Basic ${FS_API_KEY}`,
+        integration_src: INTEGRATION_SRC
     });
 
     //TODO(sabrina): make sure errors are thrown on error responses (like 401s)
@@ -45,7 +48,6 @@ describe('FullStory Events API', () => {
         };
 
         const created = await events.create(createEventsReq);
-
         expect(created).toHaveProperty('httpStatusCode', 200);
         expect(created).toHaveProperty('httpHeaders');
         expect(created).toHaveProperty('body');
@@ -101,13 +103,17 @@ describe('FullStory Events API', () => {
                 expect(imported).toEqual(
                     expect.arrayContaining([
                         expect.objectContaining({
-                            ...createReq1
+                            name: createReq1.name,
+                            context: expect.objectContaining({ integration: INTEGRATION_SRC }),
+                            properties: createReq1.properties
                         }),
                         expect.objectContaining({
-                            ...createReq2
+                            name: createReq2.name,
+                            context: expect.objectContaining({ integration: INTEGRATION_SRC }),
                         }),
                         expect.objectContaining({
-                            ...createReq3
+                            name: createReq3.name,
+                            context: expect.objectContaining({ integration: INTEGRATION_SRC }),
                         }),
                     ])
                 );

--- a/src/__tests__/users.smoke.test.ts
+++ b/src/__tests__/users.smoke.test.ts
@@ -96,7 +96,7 @@ describe('FullStory Users API', () => {
         } catch (err) {
             // Or user may be already gone
             expect(err).toBeInstanceOf(FSApiError);
-            expect(err).toHaveProperty('httpCode', 404);
+            expect(err).toHaveProperty('httpStatusCode', 404);
         }
     });
 

--- a/src/events.ts
+++ b/src/events.ts
@@ -3,7 +3,7 @@ import { CreateBatchEventsImportJobRequest, CreateBatchEventsImportJobResponse, 
 
 import { BatchJob, BatchJobOptions, IBatchJob, IBatchRequester } from './batch';
 import { FSRequestOptions, FSResponse, FullStoryOptions } from './http';
-import { addIntegrationSrc } from './utils/integrationSrc';
+import { maybeAddIntegrationSrc } from './utils/integrationSrc';
 
 ////////////////////////////////////
 //  CRUD operations
@@ -59,7 +59,7 @@ class BatchEventsRequester implements IBatchEventRequester {
 
     async requestCreateJob(requests: CreateBatchEventsImportJobRequest): Promise<CreateBatchEventsImportJobResponse> {
         for (const req of requests.requests) {
-            req.context = addIntegrationSrc(req.context, this.fsOpts.integration_src);
+            req.context = maybeAddIntegrationSrc(req.context, this.fsOpts.integration_src);
         }
         const rsp = await this.batchEventsImpl.createBatchEventsImportJob(requests);
         // make sure job metadata exist
@@ -110,7 +110,7 @@ export class Events implements IEvents {
     }
 
     async create(body: CreateEventsRequest, includeSchema?: boolean, options?: FSRequestOptions | undefined): Promise<FSResponse<CreateEventsResponse>> {
-        body.context = addIntegrationSrc(body.context, options?.integration_src);
+        body.context = maybeAddIntegrationSrc(body.context, options?.integration_src);
         return this.eventsImpl.createEvents(body, includeSchema, options);
     }
 

--- a/src/utils/__test__/integrationSrc.test.ts
+++ b/src/utils/__test__/integrationSrc.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { maybeAddIntegrationSrc } from '../integrationSrc';
+
+describe('maybeAddIntegrationSrc function', () => {
+    test('should not mutate object when no integrationSrc string provided', async () => {
+        let input = undefined;
+        let result = maybeAddIntegrationSrc(input, undefined);
+        expect(result).toBeUndefined();
+
+        input = {};
+        result = maybeAddIntegrationSrc(input, undefined);
+        expect(result).toEqual({});
+
+        input = { anything: 'should not change' } as { integration?: string; };
+        result = maybeAddIntegrationSrc(input, undefined);
+        expect(result).toEqual({ anything: 'should not change' });
+
+        result = maybeAddIntegrationSrc(input, '');
+        expect(result).toEqual({ anything: 'should not change' });
+    });
+
+    test('should not mutate object when object already have an integration string', async () => {
+        const input = { integration: 'test', anything: 'should not change' };
+        let result = maybeAddIntegrationSrc(input, '');
+        expect(result).toEqual({ integration: 'test', anything: 'should not change' });
+
+        result = maybeAddIntegrationSrc(input, 'abc');
+        expect(result).toEqual({ integration: 'test', anything: 'should not change' });
+    });
+
+    test('should add the integration string to object', async () => {
+        let input = undefined;
+        let result = maybeAddIntegrationSrc(input, 'test');
+        expect(result).toEqual({ integration: 'test' });
+
+        input = { anything: 'should not change' } as { integration?: string; };
+        result = maybeAddIntegrationSrc(input, 'test');
+        expect(result).toEqual({ integration: 'test', anything: 'should not change' });
+    });
+});

--- a/src/utils/integrationSrc.ts
+++ b/src/utils/integrationSrc.ts
@@ -1,19 +1,23 @@
-export function addIntegrationSrc<T extends { integration?: string; }>(obj: T | undefined, intgSrc: string | undefined): T | undefined {
-    if (!intgSrc) {
+// maybeAddIntegrationSrc takes an object and integration source string and
+// add the "integration" property by mutating the object.
+// Create a new object if obj is undefined.
+// Will not attempt to override any existing integration property in the object.
+export function maybeAddIntegrationSrc<T extends { integration?: string; }>(obj: T | undefined, integrationSrc: string | undefined): T | undefined {
+    if (!integrationSrc) {
         return obj;
     }
 
     if (!obj) {
         return {
-            integration: intgSrc
+            integration: integrationSrc
         } as T;
     }
 
     if (obj.integration) {
         // do not override if integration already exist
-        return;
+        return obj;
     }
 
-    obj.integration = intgSrc;
+    obj.integration = integrationSrc;
     return obj;
 }

--- a/src/utils/integrationSrc.ts
+++ b/src/utils/integrationSrc.ts
@@ -1,0 +1,19 @@
+export function addIntegrationSrc<T extends { integration?: string; }>(obj: T | undefined, intgSrc: string | undefined): T | undefined {
+    if (!intgSrc) {
+        return obj;
+    }
+
+    if (!obj) {
+        return {
+            integration: intgSrc
+        } as T;
+    }
+
+    if (obj.integration) {
+        // do not override if integration already exist
+        return;
+    }
+
+    obj.integration = intgSrc;
+    return obj;
+}

--- a/src/utils/integrationSrc.ts
+++ b/src/utils/integrationSrc.ts
@@ -13,11 +13,8 @@ export function maybeAddIntegrationSrc<T extends { integration?: string; }>(obj:
         } as T;
     }
 
-    if (obj.integration) {
-        // do not override if integration already exist
-        return obj;
+    if (!obj.integration) {
+        obj.integration = integrationSrc;
     }
-
-    obj.integration = integrationSrc;
     return obj;
 }


### PR DESCRIPTION
spread out the `integration_src` into each event's `context` if applicable.
