### PR TITLE
Sabrina/fix mock req

### DIFF
--- a/src/api/__tests__/util.ts
+++ b/src/api/__tests__/util.ts
@@ -1,7 +1,15 @@
+import * as dotenv from 'dotenv';
+dotenv.config();
+
 export const defaultHost = 'api.fullstory.com';
 
 export function makeMockReq(basePath: string, method: string, path: string, headers: any = {}) {
-    const host = process.env.FS_API_HOST || defaultHost;
+    let host = defaultHost;
+    if (process.env.FS_API_HOST) {
+        const url = new URL(process.env.FS_API_HOST);
+        host = url.host;
+    }
+
     return {
         headers: headers,
         protocol: 'https:',

--- a/src/api/__tests__/util.ts
+++ b/src/api/__tests__/util.ts
@@ -1,11 +1,12 @@
 export const defaultHost = 'api.fullstory.com';
 
 export function makeMockReq(basePath: string, method: string, path: string, headers: any = {}) {
+    const host = process.env.FS_API_HOST || defaultHost;
     return {
         headers: headers,
         protocol: 'https:',
-        hostname: defaultHost,
-        host: defaultHost,
+        hostname: host,
+        host: host,
         port: '',
         method: method,
         path: basePath + path


### PR DESCRIPTION
Fix an overside in unit tests mocks now that we could run tests on different environments. This ensures that the env vars are honored in unit tests as well