### PR TITLE
update create batch job to accept request object

### DIFF
--- a/src/__tests__/events.smoke.test.ts
+++ b/src/__tests__/events.smoke.test.ts
@@ -140,8 +140,8 @@ describe('FullStory Events API', () => {
 
         // Create A Job
         const job = events
-            .batchCreate([createReq1], { pollInterval: 1000 })
-            .add([createReq2, createReq3]);
+            .batchCreate({ requests: [createReq1] }, { pollInterval: 1000 })
+            .add(createReq2, createReq3);
 
         job.on('processing', (job) => {
             console.log('processing...', job.getId());

--- a/src/__tests__/users.smoke.test.ts
+++ b/src/__tests__/users.smoke.test.ts
@@ -122,8 +122,8 @@ describe('FullStory Users API', () => {
 
         // Create A Job
         const job = users
-            .batchCreate([createReq1], { pollInterval: 1000 })
-            .add([createReq2, createReq3]);
+            .batchCreate({ requests: [createReq1] }, { pollInterval: 1000 })
+            .add(createReq2, createReq3);
 
         job.execute();
 

--- a/src/api/__tests__/util.ts
+++ b/src/api/__tests__/util.ts
@@ -5,17 +5,23 @@ export const defaultHost = 'api.fullstory.com';
 
 export function makeMockReq(basePath: string, method: string, path: string, headers: any = {}) {
     let host = defaultHost;
+    let hostname = defaultHost;
+    let port = '';
+    let protocol = 'https:';
     if (process.env.FS_API_HOST) {
         const url = new URL(process.env.FS_API_HOST);
         host = url.host;
+        hostname = url.hostname;
+        port = url.port;
+        protocol = url.protocol;
     }
 
     return {
         headers: headers,
-        protocol: 'https:',
-        hostname: host,
+        protocol: protocol,
+        hostname: hostname,
         host: host,
-        port: '',
+        port: port,
         method: method,
         path: basePath + path
     };

--- a/src/events.ts
+++ b/src/events.ts
@@ -24,7 +24,7 @@ export interface IEventsApi {
 */
 export interface IBatchEventsApi {
     batchCreate(
-        requests?: CreateEventsRequest[],
+        request: CreateBatchEventsImportJobRequest,
         jobOptions?: BatchJobOptions
     ): BatchEventsJob;
 }
@@ -32,16 +32,16 @@ export interface IBatchEventsApi {
 /**
  * @interface IBatchEventsJob - a job for batch import events, providing job management and callbacks.
 */
-export type IBatchEventsJob = IBatchJob<CreateEventsRequest, BatchCreateEventsResponse, FailedEventsImport>;
+export type IBatchEventsJob = IBatchJob<CreateBatchEventsImportJobRequest, CreateEventsRequest, BatchCreateEventsResponse, FailedEventsImport>;
 
 /**
  * @interface IEvents - create or batch import events.
 */
 export type IEvents = IBatchEventsApi & IEventsApi;
 
-class BatchEventsJob extends BatchJob<CreateEventsRequest, CreateBatchEventsImportJobResponse, JobStatusResponse, BatchCreateEventsResponse, FailedEventsImport> {
-    constructor(fsOpts: FullStoryOptions, requests: CreateEventsRequest[] = [], opts: BatchJobOptions = {}, includeSchema = false) {
-        super(requests, new BatchEventsRequester(fsOpts, includeSchema), opts);
+class BatchEventsJob extends BatchJob<CreateBatchEventsImportJobRequest, CreateEventsRequest, CreateBatchEventsImportJobResponse, JobStatusResponse, BatchCreateEventsResponse, FailedEventsImport> {
+    constructor(fsOpts: FullStoryOptions, request: CreateBatchEventsImportJobRequest, opts: BatchJobOptions = {}, includeSchema = false) {
+        super(request, new BatchEventsRequester(fsOpts, includeSchema), opts);
     }
 }
 
@@ -58,8 +58,8 @@ class BatchEventsRequester implements IBatchEventRequester {
         this.batchEventsImpl = new FSBatchEventsApi(fsOpts);
     }
 
-    async requestCreateJob(requests: CreateBatchEventsImportJobRequest): Promise<CreateBatchEventsImportJobResponse> {
-        const rsp = await this.batchEventsImpl.createBatchEventsImportJob(requests, this.fsOpts);
+    async requestCreateJob(req: CreateBatchEventsImportJobRequest): Promise<CreateBatchEventsImportJobResponse> {
+        const rsp = await this.batchEventsImpl.createBatchEventsImportJob(req, this.fsOpts);
         // make sure job metadata exist
         const job = rsp.body;
         if (!job?.job?.id) {
@@ -111,7 +111,7 @@ export class Events implements IEvents {
         return this.eventsImpl.createEvents(body, options);
     }
 
-    batchCreate(requests?: CreateEventsRequest[] | undefined, jobOptions?: BatchJobOptions | undefined, includeSchema?: boolean): BatchEventsJob {
-        return new BatchEventsJob(this.opts, requests, jobOptions, includeSchema);
+    batchCreate(request: CreateBatchEventsImportJobRequest = { requests: [] }, jobOptions?: BatchJobOptions, includeSchema?: boolean): BatchEventsJob {
+        return new BatchEventsJob(this.opts, request, jobOptions, includeSchema);
     }
 }

--- a/src/users.ts
+++ b/src/users.ts
@@ -33,7 +33,7 @@ export interface IUsersApi {
 */
 export interface IBatchUsersApi {
     batchCreate(
-        requests?: Array<BatchUserImportRequest>,
+        request?: CreateBatchUserImportJobRequest,
         jobOptions?: BatchJobOptions
     ): BatchUsersJob;
 }
@@ -41,16 +41,16 @@ export interface IBatchUsersApi {
 /**
  * @interface IBatchUsersJob - a job for batch import users, providing job management and callbacks.
 */
-export type IBatchUsersJob = IBatchJob<BatchUserImportRequest, BatchUserImportResponse, FailedUserImport>;
+export type IBatchUsersJob = IBatchJob<CreateBatchUserImportJobRequest, BatchUserImportRequest, BatchUserImportResponse, FailedUserImport>;
 
 /**
  * @interface IUsers - CRUD operations or batch import users.
 */
 export type IUsers = IBatchUsersApi & IUsersApi;
 
-class BatchUsersJob extends BatchJob<BatchUserImportRequest, CreateBatchUserImportJobResponse, JobStatusResponse, BatchUserImportResponse, FailedUserImport> {
-    constructor(fsOpts: FullStoryOptions, requests: BatchUserImportRequest[] = [], opts: BatchJobOptions = {}, includeSchema = false) {
-        super(requests, new BatchUsersRequester(fsOpts, includeSchema), opts);
+class BatchUsersJob extends BatchJob<CreateBatchUserImportJobRequest, BatchUserImportRequest, CreateBatchUserImportJobResponse, JobStatusResponse, BatchUserImportResponse, FailedUserImport> {
+    constructor(fsOpts: FullStoryOptions, request: CreateBatchUserImportJobRequest, opts: BatchJobOptions = {}, includeSchema = false) {
+        super(request, new BatchUsersRequester(fsOpts, includeSchema), opts);
     }
 }
 export type IBatchUsersRequester = IBatchRequester<CreateBatchUserImportJobRequest, CreateBatchUserImportJobResponse, JobStatusResponse, GetBatchUserImportsResponse, GetBatchEventsImportErrorsResponse>;
@@ -66,8 +66,8 @@ class BatchUsersRequester implements IBatchUsersRequester {
         this.batchUsersImpl = new FSUsersBatchApi(fsOpts);
     }
 
-    async requestCreateJob(request: CreateBatchUserImportJobRequest): Promise<CreateBatchUserImportJobResponse> {
-        const rsp = await this.batchUsersImpl.createBatchUserImportJob(request, this.fsOpts);
+    async requestCreateJob(req: CreateBatchUserImportJobRequest): Promise<CreateBatchUserImportJobResponse> {
+        const rsp = await this.batchUsersImpl.createBatchUserImportJob(req, this.fsOpts);
         // make sure job metadata and id exist
         const job = rsp.body;
         if (!job?.job?.id) {
@@ -142,7 +142,7 @@ export class Users implements IUsers {
         return this.usersImpl.updateUser(id, body, options);
     }
 
-    batchCreate(requests: BatchUserImportRequest[] = [], jobOptions?: BatchJobOptions, includeSchema?: boolean): BatchUsersJob {
-        return new BatchUsersJob(this.opts, requests, jobOptions, includeSchema);
+    batchCreate(request: CreateBatchUserImportJobRequest = { requests: [] }, jobOptions?: BatchJobOptions, includeSchema?: boolean): BatchUsersJob {
+        return new BatchUsersJob(this.opts, request, jobOptions, includeSchema);
     }
 }


### PR DESCRIPTION
Batch job currently use `this` as request object. This will fail once the server APIs starts to reject unknown fields. It also prevents `shared` field to be in the create batch event job request.
This PR makes it that create job request uses the typed request, rather than `this` 
