### PR TITLE
Sabrina/update generator skip operations

### DIFF
--- a/openapi-generator-configs/shared/openapi-gen.config.json
+++ b/openapi-generator-configs/shared/openapi-gen.config.json
@@ -3,5 +3,8 @@
     "outputDir": ".",
     "schemaMappings": {
         "google.protobuf.NullValue": "null"
+    },
+    "skipOperations": {
+        "*": [ "/v2beta" ]
     }
 }

--- a/openapi-generator/src/test/java/com/fullstory/typescript/FullstoryTypescriptGeneratorTest.java
+++ b/openapi-generator/src/test/java/com/fullstory/typescript/FullstoryTypescriptGeneratorTest.java
@@ -6,8 +6,6 @@ import org.openapitools.codegen.ClientOptInput;
 import org.openapitools.codegen.DefaultGenerator;
 import org.openapitools.codegen.config.CodegenConfigurator;
 
-import java.util.*;
-
 /***
  * This test allows you to easily launch your code generation software under a
  * debugger.
@@ -26,18 +24,8 @@ public class FullstoryTypescriptGeneratorTest {
   // this allows you to easily set break points in FullstoryTypescriptGenerator.
   @Test
   public void launchCodeGenerator() {
-    Map<String, String> sm = new HashMap<>();
-    sm.put("google.protobuf.NullValue", "null");
-
-    Map<String, Object> ap = new HashMap<>();
-    ap.put(FullstoryTypescriptGenerator.RESOURCE_NAME, "users");
-
-    final CodegenConfigurator configurator = new CodegenConfigurator()
-        .setGeneratorName("fullstory-typescript")
-        .setInputSpec("../specs/users.sdk.swagger.json")
-        .setOutputDir("out")
-        .setSchemaMappings(sm)
-        .setAdditionalProperties(ap);
+    final CodegenConfigurator configurator = CodegenConfigurator
+        .fromFile("src/test/java/com/fullstory/typescript/test.config.json");
 
     final ClientOptInput clientOptInput = configurator.toClientOptInput();
     DefaultGenerator generator = new DefaultGenerator();

--- a/openapi-generator/src/test/java/com/fullstory/typescript/test.config.json
+++ b/openapi-generator/src/test/java/com/fullstory/typescript/test.config.json
@@ -1,0 +1,13 @@
+{
+    "generatorName": "fullstory-typescript",
+    "inputSpec": "../specs/users.sdk.swagger.json",
+    "outputDir": "out",
+    "resourceName": "users",
+    "schemaMappings": {
+        "google.protobuf.NullValue": "null"
+    },
+    "skipOperations": {
+        "*": [ "/v2beta" ],
+        "POST": [ "/v2beta" ]
+    }
+}

--- a/specs/events.swagger.json
+++ b/specs/events.swagger.json
@@ -21,7 +21,7 @@
     "application/json"
   ],
   "paths": {
-    "/v2beta/events": {
+    "/v2/events": {
       "post": {
         "summary": "Create Events",
         "description": "Creates one event with the specified details. This request can be [made idempotent](../../idempotent-requests).",
@@ -110,7 +110,7 @@
         "x-fullstory-operation-ordering": 10
       }
     },
-    "/v2beta/events/batch": {
+    "/v2/events/batch": {
       "post": {
         "summary": "Create Events Batch Import",
         "description": "Creates a batch events import job with the given list of event information.\n\nThe maximum number of request objects that can be included in a single batch request is `50,000`. This request can be [made idempotent](../../idempotent-requests).",
@@ -201,7 +201,7 @@
         "x-fullstory-operation-ordering": 10
       }
     },
-    "/v2beta/events/batch/{job_id}": {
+    "/v2/events/batch/{job_id}": {
       "get": {
         "summary": "Get Batch Import Job Details",
         "description": "Get the status for a batch events import job with job details.",
@@ -290,7 +290,7 @@
         "x-fullstory-operation-ordering": 20
       }
     },
-    "/v2beta/events/batch/{job_id}/errors": {
+    "/v2/events/batch/{job_id}/errors": {
       "get": {
         "summary": "Get Batch Import Errors",
         "description": "Get the error message and code for any events that failed from an events import job.",
@@ -390,11 +390,487 @@
         "x-fullstory-operation-ordering": 40
       }
     },
-    "/v2beta/events/batch/{job_id}/imports": {
+    "/v2/events/batch/{job_id}/imports": {
       "get": {
         "summary": "Get Batch Imported Events",
         "description": "Get the event details for successful events imported from a batch events import job.",
         "operationId": "GetBatchEventsImports",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.events.GetBatchEventsImportsResponse"
+            }
+          },
+          "202": {
+            "description": "Returned when this API is called while the job is still processing.",
+            "schema": { }
+          },
+          "400": {
+            "description": "Returned when invalid input has been provided. Fix the issue and retry.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "uid is required",
+                "code": "required_field"
+              }
+            }
+          },
+          "401": {
+            "description": "Returned when access to the resource is unauthorized.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "access is unauthorized",
+                "code": "unauthorized"
+              }
+            }
+          },
+          "403": {
+            "description": "Returned when access is not allowed due to insufficient permissions.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "insufficient permissions",
+                "code": "forbidden"
+              }
+            }
+          },
+          "404": {
+            "description": "Returned when the resource does not exist.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Requested resource does not exist",
+                "code": "resource_not_found"
+              }
+            }
+          },
+          "429": {
+            "description": "Returned when the client has exceeded the rate limit for this endpoint. A `Retry-After` header will be included with the response. This header will contain the number of seconds that you should wait before attempting to send another request.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Too many requests. Client has exceeded the rate limit for this endpoint.",
+                "code": "too_many_requests"
+              }
+            }
+          },
+          "500": {
+            "description": "Returned when a server error is encountered.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Server error was encountered",
+                "code": "server_error"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "job_id",
+            "description": "ID that can be used to check the status and retrieve results for the batch import",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page_token",
+            "description": "The token that can be used in a request to fetch the next page of results",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "include_schema",
+            "description": "Whether to include the schema in the response.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "tags": [
+          "Events",
+          "Batch Import"
+        ],
+        "x-fullstory-operation-ordering": 30
+      }
+    },
+    "/v2beta/events": {
+      "post": {
+        "summary": "Create Events",
+        "description": "Creates one event with the specified details. This request can be [made idempotent](../../idempotent-requests).",
+        "operationId": "CreateEvents2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.events.CreateEventsResponse"
+            }
+          },
+          "400": {
+            "description": "Returned when invalid input has been provided. Fix the issue and retry.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "uid is required",
+                "code": "required_field"
+              }
+            }
+          },
+          "401": {
+            "description": "Returned when access to the resource is unauthorized.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "access is unauthorized",
+                "code": "unauthorized"
+              }
+            }
+          },
+          "403": {
+            "description": "Returned when access is not allowed due to insufficient permissions.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "insufficient permissions",
+                "code": "forbidden"
+              }
+            }
+          },
+          "404": {
+            "description": "Returned when the resource does not exist.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Requested resource does not exist",
+                "code": "resource_not_found"
+              }
+            }
+          },
+          "429": {
+            "description": "Returned when the client has exceeded the rate limit for this endpoint. A `Retry-After` header will be included with the response. This header will contain the number of seconds that you should wait before attempting to send another request.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Too many requests. Client has exceeded the rate limit for this endpoint.",
+                "code": "too_many_requests"
+              }
+            }
+          },
+          "500": {
+            "description": "Returned when a server error is encountered.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Server error was encountered",
+                "code": "server_error"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.events.CreateEventsRequest"
+            }
+          }
+        ],
+        "tags": [
+          "Events"
+        ],
+        "x-fullstory-operation-ordering": 10
+      }
+    },
+    "/v2beta/events/batch": {
+      "post": {
+        "summary": "Create Events Batch Import",
+        "description": "Creates a batch events import job with the given list of event information.\n\nThe maximum number of request objects that can be included in a single batch request is `50,000`. This request can be [made idempotent](../../idempotent-requests).",
+        "operationId": "CreateBatchEventsImportJob2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.events.CreateBatchEventsImportJobResponse"
+            }
+          },
+          "400": {
+            "description": "Returned when invalid input has been provided. Fix the issue and retry.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "uid is required",
+                "code": "required_field"
+              }
+            }
+          },
+          "401": {
+            "description": "Returned when access to the resource is unauthorized.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "access is unauthorized",
+                "code": "unauthorized"
+              }
+            }
+          },
+          "403": {
+            "description": "Returned when access is not allowed due to insufficient permissions.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "insufficient permissions",
+                "code": "forbidden"
+              }
+            }
+          },
+          "404": {
+            "description": "Returned when the resource does not exist.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Requested resource does not exist",
+                "code": "resource_not_found"
+              }
+            }
+          },
+          "429": {
+            "description": "Returned when the client has exceeded the rate limit for this endpoint. A `Retry-After` header will be included with the response. This header will contain the number of seconds that you should wait before attempting to send another request.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Too many requests. Client has exceeded the rate limit for this endpoint.",
+                "code": "too_many_requests"
+              }
+            }
+          },
+          "500": {
+            "description": "Returned when a server error is encountered.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Server error was encountered",
+                "code": "server_error"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "The request payloads contains the list of events to be imported",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.events.CreateBatchEventsImportJobRequest"
+            }
+          }
+        ],
+        "tags": [
+          "Events",
+          "Batch Import"
+        ],
+        "x-fullstory-operation-ordering": 10
+      }
+    },
+    "/v2beta/events/batch/{job_id}": {
+      "get": {
+        "summary": "Get Batch Import Job Details",
+        "description": "Get the status for a batch events import job with job details.",
+        "operationId": "GetBatchEventsImportStatus2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.job.JobStatusResponse"
+            }
+          },
+          "400": {
+            "description": "Returned when invalid input has been provided. Fix the issue and retry.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "uid is required",
+                "code": "required_field"
+              }
+            }
+          },
+          "401": {
+            "description": "Returned when access to the resource is unauthorized.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "access is unauthorized",
+                "code": "unauthorized"
+              }
+            }
+          },
+          "403": {
+            "description": "Returned when access is not allowed due to insufficient permissions.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "insufficient permissions",
+                "code": "forbidden"
+              }
+            }
+          },
+          "404": {
+            "description": "Returned when the resource does not exist.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Requested resource does not exist",
+                "code": "resource_not_found"
+              }
+            }
+          },
+          "429": {
+            "description": "Returned when the client has exceeded the rate limit for this endpoint. A `Retry-After` header will be included with the response. This header will contain the number of seconds that you should wait before attempting to send another request.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Too many requests. Client has exceeded the rate limit for this endpoint.",
+                "code": "too_many_requests"
+              }
+            }
+          },
+          "500": {
+            "description": "Returned when a server error is encountered.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Server error was encountered",
+                "code": "server_error"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "job_id",
+            "description": "ID that can be used to check the status and retrieve results for the batch import",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Events",
+          "Batch Import"
+        ],
+        "x-fullstory-operation-ordering": 20
+      }
+    },
+    "/v2beta/events/batch/{job_id}/errors": {
+      "get": {
+        "summary": "Get Batch Import Errors",
+        "description": "Get the error message and code for any events that failed from an events import job.",
+        "operationId": "GetBatchEventsImportErrors2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.events.GetBatchEventsImportErrorsResponse"
+            }
+          },
+          "202": {
+            "description": "Returned when this API is called while the job is still processing.",
+            "schema": { }
+          },
+          "400": {
+            "description": "Returned when invalid input has been provided. Fix the issue and retry.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "uid is required",
+                "code": "required_field"
+              }
+            }
+          },
+          "401": {
+            "description": "Returned when access to the resource is unauthorized.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "access is unauthorized",
+                "code": "unauthorized"
+              }
+            }
+          },
+          "403": {
+            "description": "Returned when access is not allowed due to insufficient permissions.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "insufficient permissions",
+                "code": "forbidden"
+              }
+            }
+          },
+          "404": {
+            "description": "Returned when the resource does not exist.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Requested resource does not exist",
+                "code": "resource_not_found"
+              }
+            }
+          },
+          "429": {
+            "description": "Returned when the client has exceeded the rate limit for this endpoint. A `Retry-After` header will be included with the response. This header will contain the number of seconds that you should wait before attempting to send another request.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Too many requests. Client has exceeded the rate limit for this endpoint.",
+                "code": "too_many_requests"
+              }
+            }
+          },
+          "500": {
+            "description": "Returned when a server error is encountered.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Server error was encountered",
+                "code": "server_error"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "job_id",
+            "description": "ID that can be used to check the status and retrieve results for the batch import",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page_token",
+            "description": "The token that can be used in a request to fetch the next page of results",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Events",
+          "Batch Import"
+        ],
+        "x-fullstory-operation-ordering": 40
+      }
+    },
+    "/v2beta/events/batch/{job_id}/imports": {
+      "get": {
+        "summary": "Get Batch Imported Events",
+        "description": "Get the event details for successful events imported from a batch events import job.",
+        "operationId": "GetBatchEventsImports2",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -535,7 +1011,7 @@
           "browser": {
             "url": "https://store.mondaymorning.com",
             "user_agent": "square/pos",
-            "referrer_url": ""
+            "initial_referrer": ""
           }
         },
         "name": "Support Ticket",
@@ -584,7 +1060,7 @@
       "type": "object",
       "example": {
         "url": "https://app.example.com",
-        "referrer_url": "https://referrer.example.com",
+        "initial_referrer": "https://referrer.example.com",
         "user_agent": "Example Browser User Agent"
       },
       "properties": {
@@ -594,7 +1070,7 @@
         "user_agent": {
           "type": "string"
         },
-        "referrer_url": {
+        "initial_referrer": {
           "type": "string"
         }
       },
@@ -606,8 +1082,8 @@
         "browser": {
           "url": "https://example.com"
         },
-        "device": {
-          "ip": "127.0.0.1"
+        "location": {
+          "ip_address": "127.0.0.1"
         }
       },
       "properties": {
@@ -638,7 +1114,7 @@
               "browser": {
                 "url": "https://store.mondaymorning.com",
                 "user_agent": "square/pos",
-                "referrer_url": ""
+                "initial_referrer": ""
               }
             },
             "name": "Support Ticket",
@@ -661,7 +1137,7 @@
               "browser": {
                 "url": "https://store.mondaymorning.com",
                 "user_agent": "square/pos",
-                "referrer_url": ""
+                "initial_referrer": ""
               }
             },
             "name": "Support Ticket",
@@ -722,7 +1198,7 @@
           "browser": {
             "url": "https://store.mondaymorning.com",
             "user_agent": "square/pos",
-            "referrer_url": ""
+            "initial_referrer": ""
           }
         },
         "name": "Support Ticket",
@@ -772,34 +1248,14 @@
     "fullstory.v2.events.DeviceContext": {
       "type": "object",
       "example": {
-        "manufacturer": "Device Manufacturer",
-        "serial_number": "ABC123",
-        "ip": "127.0.0.1"
+        "manufacturer": "Device Manufacturer"
       },
       "properties": {
-        "ip": {
-          "type": "string"
-        },
-        "platform": {
-          "type": "string"
-        },
-        "os_version": {
-          "type": "string"
-        },
         "manufacturer": {
           "type": "string"
         },
         "model": {
           "type": "string"
-        },
-        "serial_number": {
-          "type": "string"
-        },
-        "features": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
         },
         "screen_width": {
           "type": "integer",
@@ -839,7 +1295,7 @@
                 "browser": {
                   "url": "https://store.mondaymorning.com",
                   "user_agent": "square/pos",
-                  "referrer_url": ""
+                  "initial_referrer": ""
                 }
               },
               "name": "Support Ticket",
@@ -853,7 +1309,7 @@
             }
           }
         ],
-        "total_records": 98,
+        "total_records": "98",
         "next_page_token": "asd543"
       },
       "properties": {
@@ -865,8 +1321,7 @@
           "description": "Page of events import failures for the batch import"
         },
         "total_records": {
-          "type": "integer",
-          "format": "int32",
+          "type": "string",
           "description": "The total number of failures for the specified events import"
         },
         "next_page_token": {
@@ -893,7 +1348,7 @@
             "browser": {
               "url": "https://store.mondaymorning.com",
               "user_agent": "square/pos",
-              "referrer_url": ""
+              "initial_referrer": ""
             }
           },
           "name": "Support Ticket",
@@ -942,7 +1397,7 @@
               "browser": {
                 "url": "https://store.mondaymorning.com",
                 "user_agent": "square/pos",
-                "referrer_url": ""
+                "initial_referrer": ""
               }
             },
             "name": "Support Ticket",
@@ -955,7 +1410,7 @@
             }
           }
         ],
-        "total_records": 98,
+        "total_records": "98",
         "next_page_token": "asd543"
       },
       "properties": {
@@ -967,8 +1422,7 @@
           "description": "Page of events import responses for the batch import"
         },
         "total_records": {
-          "type": "integer",
-          "format": "int32",
+          "type": "string",
           "description": "Total number of records in this batch import"
         },
         "next_page_token": {
@@ -981,20 +1435,21 @@
     "fullstory.v2.events.LocationContext": {
       "type": "object",
       "example": {
-        "country_code": "US",
-        "region_code": "US",
-        "city_name": "Atlanta"
+        "country": "US",
+        "region": "US",
+        "city": "Atlanta",
+        "ip_address": "127.0.0.1"
       },
       "properties": {
-        "country_code": {
+        "country": {
           "type": "string",
           "description": "ISO 3166-1 alpha-2 standard country code."
         },
-        "region_code": {
+        "region": {
           "type": "string",
           "description": "ISO-3166-2 standard region code."
         },
-        "city_name": {
+        "city": {
           "type": "string",
           "description": "Name of the city."
         },
@@ -1005,6 +1460,9 @@
         "longitude": {
           "type": "number",
           "format": "double"
+        },
+        "ip_address": {
+          "type": "string"
         }
       },
       "description": "The location context in which the events are attached to."
@@ -1069,7 +1527,7 @@
           "browser": {
             "url": "https://store.mondaymorning.com",
             "user_agent": "square/pos",
-            "referrer_url": ""
+            "initial_referrer": ""
           }
         }
       },
@@ -1216,7 +1674,7 @@
   "securityDefinitions": {
     "ApiKeyAuth": {
       "type": "apiKey",
-      "description": "The HTTP API requires an API key that you can generate from the FullStory app. The API key must have Admin or Architect level permissions. The header value takes the form \"Basic {YOUR_API_KEY}\".",
+      "description": "The HTTP API requires an API key that you can generate from the FullStory app. The API key must have Admin or Architect level permissions for requests which retrieve data. The header value takes the form \"Basic {YOUR_API_KEY}\".",
       "name": "Authorization",
       "in": "header"
     }

--- a/specs/users.sdk.swagger.json
+++ b/specs/users.sdk.swagger.json
@@ -21,7 +21,7 @@
     "application/json"
   ],
   "paths": {
-    "/v2beta/users": {
+    "/v2/users": {
       "get": {
         "summary": "Get Users",
         "description": "Retrieve a list of users matching the supplied filter criteria",
@@ -316,7 +316,7 @@
         "x-fullstory-operation-ordering": 10
       }
     },
-    "/v2beta/users/batch": {
+    "/v2/users/batch": {
       "post": {
         "summary": "Create Batch Import",
         "description": "Creates a batch user import job with the given list of users' information. Users are upserted (created if they do not exist or updated if they do exist).\n\n### Payload Limits\n\nThe number of request objects that can be included in a single batch request is `50,000`. This request can be [made idempotent](../../idempotent-requests).",
@@ -406,7 +406,7 @@
         "x-fullstory-operation-ordering": 10
       }
     },
-    "/v2beta/users/batch/{job_id}": {
+    "/v2/users/batch/{job_id}": {
       "get": {
         "summary": "Get Batch Import Job Details",
         "description": "Get the status for a batch user import job with job details.",
@@ -495,7 +495,7 @@
         "x-fullstory-operation-ordering": 20
       }
     },
-    "/v2beta/users/batch/{job_id}/errors": {
+    "/v2/users/batch/{job_id}/errors": {
       "get": {
         "summary": "Get Batch Import Errors",
         "description": "Get the error message and code for any users that failed from a user import job.",
@@ -595,7 +595,7 @@
         "x-fullstory-operation-ordering": 40
       }
     },
-    "/v2beta/users/batch/{job_id}/imports": {
+    "/v2/users/batch/{job_id}/imports": {
       "get": {
         "summary": "Get Batch Imported Users",
         "description": "Get the FullStory uid and user details for successful users imported from a batch user import job.",
@@ -702,7 +702,7 @@
         "x-fullstory-operation-ordering": 30
       }
     },
-    "/v2beta/users/{id}": {
+    "/v2/users/{id}": {
       "get": {
         "summary": "Get User",
         "description": "Retrieve details for a single user",
@@ -888,6 +888,964 @@
         "summary": "Update User",
         "description": "Updates a user with the specified details",
         "operationId": "UpdateUser",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.users.UpdateUserResponse"
+            }
+          },
+          "400": {
+            "description": "Returned when invalid input has been provided. Fix the issue and retry.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "uid is required",
+                "code": "required_field"
+              }
+            }
+          },
+          "401": {
+            "description": "Returned when access to the resource is unauthorized.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "access is unauthorized",
+                "code": "unauthorized"
+              }
+            }
+          },
+          "403": {
+            "description": "Returned when access is not allowed due to insufficient permissions.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "insufficient permissions",
+                "code": "forbidden"
+              }
+            }
+          },
+          "404": {
+            "description": "Returned when the resource does not exist.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Requested resource does not exist",
+                "code": "resource_not_found"
+              }
+            }
+          },
+          "429": {
+            "description": "Returned when the client has exceeded the rate limit for this endpoint. A `Retry-After` header will be included with the response. This header will contain the number of seconds that you should wait before attempting to send another request.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Too many requests. Client has exceeded the rate limit for this endpoint.",
+                "code": "too_many_requests"
+              }
+            }
+          },
+          "500": {
+            "description": "Returned when a server error is encountered",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Server error was encountered",
+                "code": "server_error"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "description": "The FullStory assigned user ID",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.users.UpdateUserRequest"
+            }
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "x-fullstory-operation-ordering": 40
+      }
+    },
+    "/v2beta/users": {
+      "get": {
+        "summary": "Get Users",
+        "description": "Retrieve a list of users matching the supplied filter criteria",
+        "operationId": "ListUsers2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.users.ListUsersResponse"
+            }
+          },
+          "400": {
+            "description": "Returned when invalid input has been provided. Fix the issue and retry.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "uid is required",
+                "code": "required_field"
+              }
+            }
+          },
+          "401": {
+            "description": "Returned when access to the resource is unauthorized.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "access is unauthorized",
+                "code": "unauthorized"
+              }
+            }
+          },
+          "403": {
+            "description": "Returned when access is not allowed due to insufficient permissions.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "insufficient permissions",
+                "code": "forbidden"
+              }
+            }
+          },
+          "404": {
+            "description": "Returned when the resource does not exist.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Requested resource does not exist",
+                "code": "resource_not_found"
+              }
+            }
+          },
+          "429": {
+            "description": "Returned when the client has exceeded the rate limit for this endpoint. A `Retry-After` header will be included with the response. This header will contain the number of seconds that you should wait before attempting to send another request.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Too many requests. Client has exceeded the rate limit for this endpoint.",
+                "code": "too_many_requests"
+              }
+            }
+          },
+          "500": {
+            "description": "Returned when a server error is encountered",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Server error was encountered",
+                "code": "server_error"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "uid",
+            "description": "The application-specific ID you've given to a user",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "email",
+            "description": "The email address associated with a user",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "display_name",
+            "description": "The nice-looking name for a user",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "is_identified",
+            "description": "Whether or not a user is anonymous or identified",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "page_token",
+            "description": "The token indicating the page of users to fetch. The same filter criteria should be supplied. This value should not be specified when requesting the first page of users.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "include_schema",
+            "description": "Whether to include schemas in the response.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "x-fullstory-operation-ordering": 30
+      },
+      "delete": {
+        "summary": "Delete User",
+        "description": "Delete a single user by uid.",
+        "operationId": "DeleteUserByUid2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.users.DeleteUserResponse"
+            }
+          },
+          "400": {
+            "description": "Returned when invalid input has been provided. Fix the issue and retry.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "uid is required",
+                "code": "required_field"
+              }
+            }
+          },
+          "401": {
+            "description": "Returned when access to the resource is unauthorized.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "access is unauthorized",
+                "code": "unauthorized"
+              }
+            }
+          },
+          "403": {
+            "description": "Returned when access is not allowed due to insufficient permissions.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "insufficient permissions",
+                "code": "forbidden"
+              }
+            }
+          },
+          "404": {
+            "description": "Returned when the resource does not exist.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Requested resource does not exist",
+                "code": "resource_not_found"
+              }
+            }
+          },
+          "429": {
+            "description": "Returned when the client has exceeded the rate limit for this endpoint. A `Retry-After` header will be included with the response. This header will contain the number of seconds that you should wait before attempting to send another request.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Too many requests. Client has exceeded the rate limit for this endpoint.",
+                "code": "too_many_requests"
+              }
+            }
+          },
+          "500": {
+            "description": "Returned when a server error is encountered",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Server error was encountered",
+                "code": "server_error"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "uid",
+            "description": "The application-specific ID you've given to the user",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Users"
+        ]
+      },
+      "post": {
+        "summary": "Create User",
+        "description": "Creates a user with the specified details. This request can be [made idempotent](../../idempotent-requests).",
+        "operationId": "CreateUser2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.users.CreateUserResponse"
+            }
+          },
+          "400": {
+            "description": "Returned when invalid input has been provided. Fix the issue and retry.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "uid is required",
+                "code": "required_field"
+              }
+            }
+          },
+          "401": {
+            "description": "Returned when access to the resource is unauthorized.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "access is unauthorized",
+                "code": "unauthorized"
+              }
+            }
+          },
+          "403": {
+            "description": "Returned when access is not allowed due to insufficient permissions.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "insufficient permissions",
+                "code": "forbidden"
+              }
+            }
+          },
+          "404": {
+            "description": "Returned when the resource does not exist.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Requested resource does not exist",
+                "code": "resource_not_found"
+              }
+            }
+          },
+          "429": {
+            "description": "Returned when the client has exceeded the rate limit for this endpoint. A `Retry-After` header will be included with the response. This header will contain the number of seconds that you should wait before attempting to send another request.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Too many requests. Client has exceeded the rate limit for this endpoint.",
+                "code": "too_many_requests"
+              }
+            }
+          },
+          "500": {
+            "description": "Returned when a server error is encountered",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Server error was encountered",
+                "code": "server_error"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.users.CreateUserRequest"
+            }
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "x-fullstory-operation-ordering": 10
+      }
+    },
+    "/v2beta/users/batch": {
+      "post": {
+        "summary": "Create Batch Import",
+        "description": "Creates a batch user import job with the given list of users' information. Users are upserted (created if they do not exist or updated if they do exist).\n\n### Payload Limits\n\nThe number of request objects that can be included in a single batch request is `50,000`. This request can be [made idempotent](../../idempotent-requests).",
+        "operationId": "CreateBatchUserImportJob2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.users.CreateBatchUserImportJobResponse"
+            }
+          },
+          "400": {
+            "description": "Returned when invalid input has been provided. Fix the issue and retry.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "uid is required",
+                "code": "required_field"
+              }
+            }
+          },
+          "401": {
+            "description": "Returned when access to the resource is unauthorized.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "access is unauthorized",
+                "code": "unauthorized"
+              }
+            }
+          },
+          "403": {
+            "description": "Returned when access is not allowed due to insufficient permissions.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "insufficient permissions",
+                "code": "forbidden"
+              }
+            }
+          },
+          "404": {
+            "description": "Returned when the resource does not exist.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Requested resource does not exist",
+                "code": "resource_not_found"
+              }
+            }
+          },
+          "429": {
+            "description": "Returned when the client has exceeded the rate limit for this endpoint. A `Retry-After` header will be included with the response. This header will contain the number of seconds that you should wait before attempting to send another request.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Too many requests. Client has exceeded the rate limit for this endpoint.",
+                "code": "too_many_requests"
+              }
+            }
+          },
+          "500": {
+            "description": "Returned when a server error is encountered",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Server error was encountered",
+                "code": "server_error"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.users.CreateBatchUserImportJobRequest"
+            }
+          }
+        ],
+        "tags": [
+          "Users",
+          "Batch Import"
+        ],
+        "x-fullstory-operation-ordering": 10
+      }
+    },
+    "/v2beta/users/batch/{job_id}": {
+      "get": {
+        "summary": "Get Batch Import Job Details",
+        "description": "Get the status for a batch user import job with job details.",
+        "operationId": "GetBatchUserImportStatus2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.job.JobStatusResponse"
+            }
+          },
+          "400": {
+            "description": "Returned when invalid input has been provided. Fix the issue and retry.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "uid is required",
+                "code": "required_field"
+              }
+            }
+          },
+          "401": {
+            "description": "Returned when access to the resource is unauthorized.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "access is unauthorized",
+                "code": "unauthorized"
+              }
+            }
+          },
+          "403": {
+            "description": "Returned when access is not allowed due to insufficient permissions.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "insufficient permissions",
+                "code": "forbidden"
+              }
+            }
+          },
+          "404": {
+            "description": "Returned when the resource does not exist.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Requested resource does not exist",
+                "code": "resource_not_found"
+              }
+            }
+          },
+          "429": {
+            "description": "Returned when the client has exceeded the rate limit for this endpoint. A `Retry-After` header will be included with the response. This header will contain the number of seconds that you should wait before attempting to send another request.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Too many requests. Client has exceeded the rate limit for this endpoint.",
+                "code": "too_many_requests"
+              }
+            }
+          },
+          "500": {
+            "description": "Returned when a server error is encountered",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Server error was encountered",
+                "code": "server_error"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "job_id",
+            "description": "ID that can be used to check the status and retrieve results for the batch import",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Users",
+          "Batch Import"
+        ],
+        "x-fullstory-operation-ordering": 20
+      }
+    },
+    "/v2beta/users/batch/{job_id}/errors": {
+      "get": {
+        "summary": "Get Batch Import Errors",
+        "description": "Get the error message and code for any users that failed from a user import job.",
+        "operationId": "GetBatchUserImportErrors2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.users.GetBatchUserImportErrorsResponse"
+            }
+          },
+          "202": {
+            "description": "Returned when this API is called while the job that is still processing.",
+            "schema": { }
+          },
+          "400": {
+            "description": "Returned when invalid input has been provided. Fix the issue and retry.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "uid is required",
+                "code": "required_field"
+              }
+            }
+          },
+          "401": {
+            "description": "Returned when access to the resource is unauthorized.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "access is unauthorized",
+                "code": "unauthorized"
+              }
+            }
+          },
+          "403": {
+            "description": "Returned when access is not allowed due to insufficient permissions.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "insufficient permissions",
+                "code": "forbidden"
+              }
+            }
+          },
+          "404": {
+            "description": "Returned when the resource does not exist.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Requested resource does not exist",
+                "code": "resource_not_found"
+              }
+            }
+          },
+          "429": {
+            "description": "Returned when the client has exceeded the rate limit for this endpoint. A `Retry-After` header will be included with the response. This header will contain the number of seconds that you should wait before attempting to send another request.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Too many requests. Client has exceeded the rate limit for this endpoint.",
+                "code": "too_many_requests"
+              }
+            }
+          },
+          "500": {
+            "description": "Returned when a server error is encountered",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Server error was encountered",
+                "code": "server_error"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "job_id",
+            "description": "ID that can be used to check the status and retrieve results for the batch import",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page_token",
+            "description": "The token that can be used in a request to fetch the next page of results",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Users",
+          "Batch Import"
+        ],
+        "x-fullstory-operation-ordering": 40
+      }
+    },
+    "/v2beta/users/batch/{job_id}/imports": {
+      "get": {
+        "summary": "Get Batch Imported Users",
+        "description": "Get the FullStory uid and user details for successful users imported from a batch user import job.",
+        "operationId": "GetBatchUserImports2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.users.GetBatchUserImportsResponse"
+            }
+          },
+          "202": {
+            "description": "Returned when this API is called while the job that is still processing.",
+            "schema": { }
+          },
+          "400": {
+            "description": "Returned when invalid input has been provided. Fix the issue and retry.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "uid is required",
+                "code": "required_field"
+              }
+            }
+          },
+          "401": {
+            "description": "Returned when access to the resource is unauthorized.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "access is unauthorized",
+                "code": "unauthorized"
+              }
+            }
+          },
+          "403": {
+            "description": "Returned when access is not allowed due to insufficient permissions.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "insufficient permissions",
+                "code": "forbidden"
+              }
+            }
+          },
+          "404": {
+            "description": "Returned when the resource does not exist.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Requested resource does not exist",
+                "code": "resource_not_found"
+              }
+            }
+          },
+          "429": {
+            "description": "Returned when the client has exceeded the rate limit for this endpoint. A `Retry-After` header will be included with the response. This header will contain the number of seconds that you should wait before attempting to send another request.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Too many requests. Client has exceeded the rate limit for this endpoint.",
+                "code": "too_many_requests"
+              }
+            }
+          },
+          "500": {
+            "description": "Returned when a server error is encountered",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Server error was encountered",
+                "code": "server_error"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "job_id",
+            "description": "ID that can be used to check the status and retrieve results for the batch import",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page_token",
+            "description": "The token that can be used in a request to fetch the next page of results",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "include_schema",
+            "description": "Whether to include schemas in the response.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "tags": [
+          "Users",
+          "Batch Import"
+        ],
+        "x-fullstory-operation-ordering": 30
+      }
+    },
+    "/v2beta/users/{id}": {
+      "get": {
+        "summary": "Get User",
+        "description": "Retrieve details for a single user",
+        "operationId": "GetUser2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.users.GetUserResponse"
+            }
+          },
+          "400": {
+            "description": "Returned when invalid input has been provided. Fix the issue and retry.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "uid is required",
+                "code": "required_field"
+              }
+            }
+          },
+          "401": {
+            "description": "Returned when access to the resource is unauthorized.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "access is unauthorized",
+                "code": "unauthorized"
+              }
+            }
+          },
+          "403": {
+            "description": "Returned when access is not allowed due to insufficient permissions.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "insufficient permissions",
+                "code": "forbidden"
+              }
+            }
+          },
+          "404": {
+            "description": "Returned when the resource does not exist.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Requested resource does not exist",
+                "code": "resource_not_found"
+              }
+            }
+          },
+          "429": {
+            "description": "Returned when the client has exceeded the rate limit for this endpoint. A `Retry-After` header will be included with the response. This header will contain the number of seconds that you should wait before attempting to send another request.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Too many requests. Client has exceeded the rate limit for this endpoint.",
+                "code": "too_many_requests"
+              }
+            }
+          },
+          "500": {
+            "description": "Returned when a server error is encountered",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Server error was encountered",
+                "code": "server_error"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "description": "The FullStory assigned user ID",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "include_schema",
+            "description": "Whether to include the schema in the response.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "x-fullstory-operation-ordering": 20
+      },
+      "delete": {
+        "summary": "Delete User",
+        "description": "Delete a single user. `id` may be supplied as a path parameter, or `uid` as a query parameter. One or the other is required. ex: `/v2beta/users?uid={uid}` or `/v2beta/users/{id}`",
+        "operationId": "DeleteUser2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.users.DeleteUserResponse"
+            }
+          },
+          "400": {
+            "description": "Returned when invalid input has been provided. Fix the issue and retry.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "uid is required",
+                "code": "required_field"
+              }
+            }
+          },
+          "401": {
+            "description": "Returned when access to the resource is unauthorized.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "access is unauthorized",
+                "code": "unauthorized"
+              }
+            }
+          },
+          "403": {
+            "description": "Returned when access is not allowed due to insufficient permissions.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "insufficient permissions",
+                "code": "forbidden"
+              }
+            }
+          },
+          "404": {
+            "description": "Returned when the resource does not exist.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Requested resource does not exist",
+                "code": "resource_not_found"
+              }
+            }
+          },
+          "429": {
+            "description": "Returned when the client has exceeded the rate limit for this endpoint. A `Retry-After` header will be included with the response. This header will contain the number of seconds that you should wait before attempting to send another request.",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Too many requests. Client has exceeded the rate limit for this endpoint.",
+                "code": "too_many_requests"
+              }
+            }
+          },
+          "500": {
+            "description": "Returned when a server error is encountered",
+            "schema": {
+              "$ref": "#/definitions/fullstory.v2.apierror.ErrorResponse",
+              "example": {
+                "message": "Server error was encountered",
+                "code": "server_error"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "description": "The FullStory-generated id for the user - not required if `uid` is passed as a query parameter",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "x-fullstory-sdk-description-override": "The FullStory-generated id for the user."
+          }
+        ],
+        "tags": [
+          "Users"
+        ],
+        "x-fullstory-operation-ordering": 50,
+        "x-fullstory-sdk-description-override": "Delete a single user by FullStory generated user ID."
+      },
+      "post": {
+        "summary": "Update User",
+        "description": "Updates a user with the specified details",
+        "operationId": "UpdateUser2",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1316,7 +2274,7 @@
             }
           }
         ],
-        "total_records": 98,
+        "total_records": "98",
         "next_page_token": "asd543"
       },
       "properties": {
@@ -1328,8 +2286,7 @@
           "description": "Page of user import failures for the batch import"
         },
         "total_records": {
-          "type": "integer",
-          "format": "int32",
+          "type": "string",
           "description": "The total number of failures for the specified user import"
         },
         "next_page_token": {
@@ -1405,7 +2362,7 @@
             }
           }
         ],
-        "total_records": 98,
+        "total_records": "98",
         "next_page_token": "asd543"
       },
       "properties": {
@@ -1417,8 +2374,7 @@
           "description": "Page of user import responses for the batch import"
         },
         "total_records": {
-          "type": "integer",
-          "format": "int32",
+          "type": "string",
           "description": "Total number of records in this batch import"
         },
         "next_page_token": {
@@ -1509,7 +2465,7 @@
             }
           }
         ],
-        "total_records": 1200,
+        "total_records": "1200",
         "next_page_token": "asd543"
       },
       "properties": {
@@ -1521,8 +2477,7 @@
           "description": "The list of users that match the input filter criteria"
         },
         "total_records": {
-          "type": "integer",
-          "format": "int32",
+          "type": "string",
           "description": "The total number of users that matched the filter criteria"
         },
         "next_page_token": {
@@ -1627,7 +2582,7 @@
   "securityDefinitions": {
     "ApiKeyAuth": {
       "type": "apiKey",
-      "description": "The HTTP API requires an API key that you can generate from the FullStory app. The API key must have Admin or Architect level permissions. The header value takes the form \"Basic {YOUR_API_KEY}\"",
+      "description": "The HTTP API requires an API key that you can generate from the FullStory app. The API key must have Admin or Architect level permissions for requests which retrieve data. The header value takes the form \"Basic {YOUR_API_KEY}\"",
       "name": "Authorization",
       "in": "header"
     }

--- a/src/api/__tests__/events.test.ts
+++ b/src/api/__tests__/events.test.ts
@@ -5,7 +5,7 @@ import { EventsApi, EventsBatchImportApi } from '..';
 import { makeMockReq } from './util';
 
 const MOCK_API_KEY = 'MOCK_API_KEY';
-const basePath = '/v2beta/events';
+const basePath = '/v2/events';
 const expectedHeaders = { accept: 'application/json' };
 
 const mockRequest = jest.fn();

--- a/src/api/__tests__/users.test.ts
+++ b/src/api/__tests__/users.test.ts
@@ -6,7 +6,7 @@ import { UsersApi, UsersBatchImportApi } from '../index';
 import { makeMockReq } from './util';
 
 const MOCK_API_KEY = 'MOCK_API_KEY';
-const basePath = '/v2beta/users';
+const basePath = '/v2/users';
 const expectedHeaders = { accept: 'application/json' };
 
 const mockRequest = jest.fn<any>();

--- a/src/api/events/EventsApi.ts
+++ b/src/api/events/EventsApi.ts
@@ -36,7 +36,7 @@ export class EventsApi {
      * @param body
     */
     public async createEvents(body: CreateEventsRequest, options?: FSRequestOptions): Promise<FSResponse<void>> {
-        const apiPath = `${this.basePath}/v2beta/events`;
+        const apiPath = `${this.basePath}/v2/events`;
         const url = new URL(apiPath);
 
         const queryParams: URLSearchParams = new URLSearchParams();

--- a/src/api/events/EventsBatchImportApi.ts
+++ b/src/api/events/EventsBatchImportApi.ts
@@ -36,7 +36,7 @@ export class EventsBatchImportApi {
      * @param body The request payloads contains the list of events to be imported
     */
     public async createBatchEventsImportJob(body: CreateBatchEventsImportJobRequest, options?: FSRequestOptions): Promise<FSResponse<CreateBatchEventsImportJobResponse>> {
-        const apiPath = `${this.basePath}/v2beta/events/batch`;
+        const apiPath = `${this.basePath}/v2/events/batch`;
         const url = new URL(apiPath);
 
         const queryParams: URLSearchParams = new URLSearchParams();
@@ -77,7 +77,7 @@ export class EventsBatchImportApi {
      * @param pageToken The token that can be used in a request to fetch the next page of results
     */
     public async getBatchEventsImportErrors(jobId: string, pageToken?: string, options?: FSRequestOptions): Promise<FSResponse<GetBatchEventsImportErrorsResponse>> {
-        const apiPath = `${this.basePath}/v2beta/events/batch/{job_id}/errors`
+        const apiPath = `${this.basePath}/v2/events/batch/{job_id}/errors`
             .replace('{' + 'job_id' + '}', encodeURIComponent(String(jobId)));
         const url = new URL(apiPath);
 
@@ -113,7 +113,7 @@ export class EventsBatchImportApi {
      * @param jobId ID that can be used to check the status and retrieve results for the batch import
     */
     public async getBatchEventsImportStatus(jobId: string, options?: FSRequestOptions): Promise<FSResponse<JobStatusResponse>> {
-        const apiPath = `${this.basePath}/v2beta/events/batch/{job_id}`
+        const apiPath = `${this.basePath}/v2/events/batch/{job_id}`
             .replace('{' + 'job_id' + '}', encodeURIComponent(String(jobId)));
         const url = new URL(apiPath);
 
@@ -148,7 +148,7 @@ export class EventsBatchImportApi {
      * @param includeSchema Whether to include the schema in the response.
     */
     public async getBatchEventsImports(jobId: string, pageToken?: string, includeSchema?: boolean, options?: FSRequestOptions): Promise<FSResponse<GetBatchEventsImportsResponse>> {
-        const apiPath = `${this.basePath}/v2beta/events/batch/{job_id}/imports`
+        const apiPath = `${this.basePath}/v2/events/batch/{job_id}/imports`
             .replace('{' + 'job_id' + '}', encodeURIComponent(String(jobId)));
         const url = new URL(apiPath);
 

--- a/src/api/users/UsersApi.ts
+++ b/src/api/users/UsersApi.ts
@@ -36,7 +36,7 @@ export class UsersApi {
      * @param body
     */
     public async createUser(body: CreateUserRequest, options?: FSRequestOptions): Promise<FSResponse<CreateUserResponse>> {
-        const apiPath = `${this.basePath}/v2beta/users`;
+        const apiPath = `${this.basePath}/v2/users`;
         const url = new URL(apiPath);
 
         const queryParams: URLSearchParams = new URLSearchParams();
@@ -76,7 +76,7 @@ export class UsersApi {
      * @param id The FullStory-generated id for the user.
     */
     public async deleteUser(id: string, options?: FSRequestOptions): Promise<FSResponse<void>> {
-        const apiPath = `${this.basePath}/v2beta/users/{id}`
+        const apiPath = `${this.basePath}/v2/users/{id}`
             .replace('{' + 'id' + '}', encodeURIComponent(String(id)));
         const url = new URL(apiPath);
 
@@ -109,7 +109,7 @@ export class UsersApi {
      * @param uid The application-specific ID you've given to the user
     */
     public async deleteUserByUid(uid?: string, options?: FSRequestOptions): Promise<FSResponse<void>> {
-        const apiPath = `${this.basePath}/v2beta/users`;
+        const apiPath = `${this.basePath}/v2/users`;
         const url = new URL(apiPath);
 
         const queryParams: URLSearchParams = new URLSearchParams();
@@ -145,7 +145,7 @@ export class UsersApi {
      * @param includeSchema Whether to include the schema in the response.
     */
     public async getUser(id: string, includeSchema?: boolean, options?: FSRequestOptions): Promise<FSResponse<GetUserResponse>> {
-        const apiPath = `${this.basePath}/v2beta/users/{id}`
+        const apiPath = `${this.basePath}/v2/users/{id}`
             .replace('{' + 'id' + '}', encodeURIComponent(String(id)));
         const url = new URL(apiPath);
 
@@ -186,7 +186,7 @@ export class UsersApi {
      * @param includeSchema Whether to include schemas in the response.
     */
     public async listUsers(uid?: string, email?: string, displayName?: string, isIdentified?: boolean, pageToken?: string, includeSchema?: boolean, options?: FSRequestOptions): Promise<FSResponse<ListUsersResponse>> {
-        const apiPath = `${this.basePath}/v2beta/users`;
+        const apiPath = `${this.basePath}/v2/users`;
         const url = new URL(apiPath);
 
         const queryParams: URLSearchParams = new URLSearchParams();
@@ -237,7 +237,7 @@ export class UsersApi {
      * @param body
     */
     public async updateUser(id: string, body: UpdateUserRequest, options?: FSRequestOptions): Promise<FSResponse<UpdateUserResponse>> {
-        const apiPath = `${this.basePath}/v2beta/users/{id}`
+        const apiPath = `${this.basePath}/v2/users/{id}`
             .replace('{' + 'id' + '}', encodeURIComponent(String(id)));
         const url = new URL(apiPath);
 

--- a/src/api/users/UsersBatchImportApi.ts
+++ b/src/api/users/UsersBatchImportApi.ts
@@ -36,7 +36,7 @@ export class UsersBatchImportApi {
      * @param body
     */
     public async createBatchUserImportJob(body: CreateBatchUserImportJobRequest, options?: FSRequestOptions): Promise<FSResponse<CreateBatchUserImportJobResponse>> {
-        const apiPath = `${this.basePath}/v2beta/users/batch`;
+        const apiPath = `${this.basePath}/v2/users/batch`;
         const url = new URL(apiPath);
 
         const queryParams: URLSearchParams = new URLSearchParams();
@@ -77,7 +77,7 @@ export class UsersBatchImportApi {
      * @param pageToken The token that can be used in a request to fetch the next page of results
     */
     public async getBatchUserImportErrors(jobId: string, pageToken?: string, options?: FSRequestOptions): Promise<FSResponse<GetBatchUserImportErrorsResponse>> {
-        const apiPath = `${this.basePath}/v2beta/users/batch/{job_id}/errors`
+        const apiPath = `${this.basePath}/v2/users/batch/{job_id}/errors`
             .replace('{' + 'job_id' + '}', encodeURIComponent(String(jobId)));
         const url = new URL(apiPath);
 
@@ -113,7 +113,7 @@ export class UsersBatchImportApi {
      * @param jobId ID that can be used to check the status and retrieve results for the batch import
     */
     public async getBatchUserImportStatus(jobId: string, options?: FSRequestOptions): Promise<FSResponse<JobStatusResponse>> {
-        const apiPath = `${this.basePath}/v2beta/users/batch/{job_id}`
+        const apiPath = `${this.basePath}/v2/users/batch/{job_id}`
             .replace('{' + 'job_id' + '}', encodeURIComponent(String(jobId)));
         const url = new URL(apiPath);
 
@@ -148,7 +148,7 @@ export class UsersBatchImportApi {
      * @param includeSchema Whether to include schemas in the response.
     */
     public async getBatchUserImports(jobId: string, pageToken?: string, includeSchema?: boolean, options?: FSRequestOptions): Promise<FSResponse<GetBatchUserImportsResponse>> {
-        const apiPath = `${this.basePath}/v2beta/users/batch/{job_id}/imports`
+        const apiPath = `${this.basePath}/v2/users/batch/{job_id}/imports`
             .replace('{' + 'job_id' + '}', encodeURIComponent(String(jobId)));
         const url = new URL(apiPath);
 

--- a/src/model/events/BrowserContext.ts
+++ b/src/model/events/BrowserContext.ts
@@ -11,6 +11,6 @@
 export interface BrowserContext {
     'url'?: string;
     'user_agent'?: string;
-    'referrer_url'?: string;
+    'initial_referrer'?: string;
 }
 

--- a/src/model/events/DeviceContext.ts
+++ b/src/model/events/DeviceContext.ts
@@ -9,13 +9,8 @@
  * @interface DeviceContext The device context in which the events are attached to.
  */
 export interface DeviceContext {
-    'ip'?: string;
-    'platform'?: string;
-    'os_version'?: string;
     'manufacturer'?: string;
     'model'?: string;
-    'serial_number'?: string;
-    'features'?: Array<string>;
     'screen_width'?: number;
     'screen_height'?: number;
     'viewport_width'?: number;

--- a/src/model/events/GetBatchEventsImportErrorsResponse.ts
+++ b/src/model/events/GetBatchEventsImportErrorsResponse.ts
@@ -17,7 +17,7 @@ export interface GetBatchEventsImportErrorsResponse {
     /**
      * The total number of failures for the specified events import
      */
-    'total_records'?: number;
+    'total_records'?: string;
     /**
      * The token that can be used in a subsequent request to fetch the next page of import failures
      */

--- a/src/model/events/GetBatchEventsImportsResponse.ts
+++ b/src/model/events/GetBatchEventsImportsResponse.ts
@@ -17,7 +17,7 @@ export interface GetBatchEventsImportsResponse {
     /**
      * Total number of records in this batch import
      */
-    'total_records'?: number;
+    'total_records'?: string;
     /**
      * The token that can be used in a subsequent request to fetch the next page of import results
      */

--- a/src/model/events/LocationContext.ts
+++ b/src/model/events/LocationContext.ts
@@ -12,16 +12,17 @@ export interface LocationContext {
     /**
      * ISO 3166-1 alpha-2 standard country code.
      */
-    'country_code'?: string;
+    'country'?: string;
     /**
      * ISO-3166-2 standard region code.
      */
-    'region_code'?: string;
+    'region'?: string;
     /**
      * Name of the city.
      */
-    'city_name'?: string;
+    'city'?: string;
     'latitude'?: number;
     'longitude'?: number;
+    'ip_address'?: string;
 }
 

--- a/src/model/users/GetBatchUserImportErrorsResponse.ts
+++ b/src/model/users/GetBatchUserImportErrorsResponse.ts
@@ -17,7 +17,7 @@ export interface GetBatchUserImportErrorsResponse {
     /**
      * The total number of failures for the specified user import
      */
-    'total_records': number;
+    'total_records': string;
     /**
      * The token that can be used in a subsequent request to fetch the next page of import failures
      */

--- a/src/model/users/GetBatchUserImportsResponse.ts
+++ b/src/model/users/GetBatchUserImportsResponse.ts
@@ -17,7 +17,7 @@ export interface GetBatchUserImportsResponse {
     /**
      * Total number of records in this batch import
      */
-    'total_records': number;
+    'total_records': string;
     /**
      * The token that can be used in a subsequent request to fetch the next page of import results
      */

--- a/src/model/users/ListUsersResponse.ts
+++ b/src/model/users/ListUsersResponse.ts
@@ -17,7 +17,7 @@ export interface ListUsersResponse {
     /**
      * The total number of users that matched the filter criteria
      */
-    'total_records': number;
+    'total_records': string;
     /**
      * The token that can be used in a subsequent request with the same filter criteria to fetch the next page of users
      */


### PR DESCRIPTION
- Update swagger spec to use the latest swagger, regenerate the models, apis, and updated the tests
- Add an cli/confi option for `skipOperations`, to allow users to pass in certain operations to be skipped based on the http method and path prefix
  - add `skipOperations` to skip any `/v2btea' endpints
- update java test to use json config, makes it easier to test any options in json format