### PR TITLE
make batchCreate reqeust body optional

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -24,7 +24,7 @@ interface EventsApi {
 */
 interface BatchEventsApi {
     batchCreate(
-        request: {
+        request?: {
             body: CreateBatchEventsImportJobRequest,
             includeSchema?: boolean,
         },
@@ -43,7 +43,7 @@ export type BatchEventsJob = BatchJob<CreateBatchEventsImportJobRequest, CreateE
 export type Events = BatchEventsApi & EventsApi;
 
 class BatchEventsJobImpl extends BatchJobImpl<CreateBatchEventsImportJobRequest, CreateEventRequest, CreateBatchEventsImportJobResponse, JobStatusResponse, BatchCreateEventsResponse, FailedEventsImport> {
-    constructor(fsOpts: FullStoryOptions, request: CreateBatchEventsImportJobRequest, opts: BatchJobOptions = {}, includeSchema = false) {
+    constructor(fsOpts: FullStoryOptions, request: CreateBatchEventsImportJobRequest = { requests: [] }, opts: BatchJobOptions = {}, includeSchema = false) {
         super(request, new BatchEventsRequesterImpl(fsOpts, includeSchema), opts);
     }
 }
@@ -117,7 +117,7 @@ export class EventsImpl implements Events, WithOptions<Events> {
         return this.eventsImpl.createEvent(...request);
     }
 
-    batchCreate(request: { body: CreateBatchEventsImportJobRequest, includeSchema?: boolean; }, jobOptions?: BatchJobOptions): BatchEventsJob {
-        return new BatchEventsJobImpl(this.opts, request.body, jobOptions, request.includeSchema);
+    batchCreate(request?: { body: CreateBatchEventsImportJobRequest, includeSchema?: boolean; }, jobOptions?: BatchJobOptions): BatchEventsJob {
+        return new BatchEventsJobImpl(this.opts, request?.body, jobOptions, request?.includeSchema);
     }
 }

--- a/src/users.ts
+++ b/src/users.ts
@@ -33,7 +33,7 @@ interface UsersApi {
 */
 interface BatchUsersApi {
     batchCreate(
-        request: {
+        request?: {
             body: CreateBatchUserImportJobRequest,
             includeSchema?: boolean,
         },
@@ -52,7 +52,7 @@ export type BatchUsersJob = BatchJob<CreateBatchUserImportJobRequest, BatchUserI
 export type Users = BatchUsersApi & UsersApi;
 
 class BatchUsersJobImpl extends BatchJobImpl<CreateBatchUserImportJobRequest, BatchUserImportRequest, CreateBatchUserImportJobResponse, JobStatusResponse, BatchUserImportResponse, FailedUserImport> {
-    constructor(fsOpts: FullStoryOptions, request: CreateBatchUserImportJobRequest, opts: BatchJobOptions = {}, includeSchema = false) {
+    constructor(fsOpts: FullStoryOptions, request: CreateBatchUserImportJobRequest = { requests: [] }, opts: BatchJobOptions = {}, includeSchema = false) {
         super(request, new BatchUsersRequesterImpl(fsOpts, includeSchema), opts);
     }
 }
@@ -150,7 +150,7 @@ export class UsersImpl implements Users, WithOptions<Users> {
         return this.usersImpl.updateUser(...request);
     }
 
-    batchCreate(request: { body: CreateBatchUserImportJobRequest, includeSchema?: boolean; }, jobOptions?: BatchJobOptions): BatchUsersJob {
-        return new BatchUsersJobImpl(this.opts, request.body, jobOptions, request.includeSchema);
+    batchCreate(request?: { body: CreateBatchUserImportJobRequest, includeSchema?: boolean; }, jobOptions?: BatchJobOptions): BatchUsersJob {
+        return new BatchUsersJobImpl(this.opts, request?.body, jobOptions, request?.includeSchema);
     }
 }


### PR DESCRIPTION
Last change pre v1:
make `request` optional for`batchCreate` so that
```ts
events.batchCreate()
// becomes short-hand for
events.batchCreate({ body: { requests: [] }})
```