### PR TITLE
move include schema and mark it deprecated from createbatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,12 +165,7 @@ const fsClient = init({ apiKey: '<YOUR_API_KEY>' });
   ];
 
   // create a job object
-  const job = users.batchCreate({
-    body: { requests },
-    // include schema in the server response
-    // when retrieving imported users
-    includeSchema: true,
-  });
+  const job = users.batchCreate({ requests });
 
   // you can add more requests before executing
   job.add(
@@ -206,10 +201,7 @@ const fsClient = init({ apiKey: '<YOUR_API_KEY>' });
   ];
 
   // create a job object
-  const job = events.batchCreate({ 
-    body: { requests }
-    includeSchema: true,
-  });
+  const job = events.batchCreate({ requests });
 
   // you can add more requests before executing
   job.add({
@@ -290,9 +282,8 @@ const fsClient = init({ apiKey: '<YOUR_API_KEY>' });
 
   ```ts
   // restart failed job
-  const job = events.batchCreate({
-    body: { requests }
-  });
+  const job = events.batchCreate({ requests });
+
   job.on('abort', () => {
     // logic to determine if should restart
     baseJob.restart();
@@ -331,24 +322,45 @@ Using `withOptions` will **not** modify the options initially provided, but retu
 ```
 
 #### Batch Job Options
+
 - Batch Import Options
 
   Each job can be created with different options. Additional request options can also be provided when creating the job, the request options will be applied to all server API requests such as requests to check for job status.
 
   ```ts
-  const options: BatchJobOptions = {
+  const jobOptions: BatchJobOptions = {
     // poll job status every one minute
     pollInterval: 60000,
     // retry 5 times on API errors before aborting
     maxRetry: 5,
+    // include schema in the server response
+    // when retrieving imported users
+    includeSchema: true,
   }
   
   const createResponse = await users.batchCreate(
-      { 
-        body: { requests: [{ uid: 'user123' }] },
+      { requests: [{ uid: 'user123' }] },
+      jobOptions
+  );
+  ```
+
+- Using Both Request Options and Batch Job Options
+  It is possible to `withOptions` for batch jobs as well. Setting request options will ensure that the request options is used for all server API requests originated from the job, including creating the job, getting the job status and getting job's results. And job options configure the behavior of the batch job itself.
+  
+  ```ts
+  const createResponse = await users
+  .withOptions({
+    // request options will be used for all server API requests for this job
+    integrationSource: 'SPECIAL_INTEGRATION_SOURCE'
+  })
+  .batchCreate(
+      { requests: [{ uid: 'user123' }]},
+      // any batch job options for this job
+      {
+        pollInterval: 60000,
+        maxRetry: 5,
         includeSchema: true,
-      },
-      options
+      }
   );
   ```
 

--- a/src/__tests__/events.smoke.test.ts
+++ b/src/__tests__/events.smoke.test.ts
@@ -139,7 +139,7 @@ describe('FullStory Events API', () => {
 
         // Create A Job
         const job = events
-            .batchCreate({ body: { requests: [createReq1] } }, { pollInterval: 1000 })
+            .batchCreate({ requests: [createReq1] }, { pollInterval: 1000 })
             .add(createReq2, createReq3);
 
         job.on('processing', (job) => {

--- a/src/__tests__/events.test.ts
+++ b/src/__tests__/events.test.ts
@@ -104,7 +104,7 @@ describe('FullStory Events API', () => {
             body: {},
         });
 
-        const job = events.batchCreate({ body: createJobReq });
+        const job = events.batchCreate(createJobReq);
         expect(mockJobCreate).toBeCalledTimes(0);
         job.on('abort', (errs: Error[]) => {
             throw errs;
@@ -144,7 +144,7 @@ describe('FullStory Events API', () => {
             body: {},
         });
 
-        const job = events.withOptions({ integrationSource: MOCK_INTEGRATION_SOURCE }).batchCreate({ body: createJobReq }, { pollInterval: 1000, maxRetry: 5 });
+        const job = events.withOptions({ integrationSource: MOCK_INTEGRATION_SOURCE }).batchCreate(createJobReq, { pollInterval: 1000, maxRetry: 5, includeSchema: true });
         expect(mockJobCreate).toBeCalledTimes(0);
 
         job.on('done', () => {
@@ -154,6 +154,11 @@ describe('FullStory Events API', () => {
             expect(mockJobStatus).toBeCalledWith(
                 { jobId: MOCK_JOB_ID },
             );
+            expect(mockJobImports).toBeCalledWith({
+                includeSchema: true,
+                jobId: MOCK_JOB_ID,
+            });
+            expect(mockJobErrors).toBeCalledTimes(0);
             done();
         });
 

--- a/src/__tests__/users.smoke.test.ts
+++ b/src/__tests__/users.smoke.test.ts
@@ -65,6 +65,7 @@ describe('FullStory Users API', () => {
                 properties: expect.objectContaining(createReq.properties as any),
             })
         );
+        expect(got.body?.schema).toBeDefined();
 
         // Update user
         const updateReq: UpdateUserRequest = {
@@ -143,11 +144,11 @@ describe('FullStory Users API', () => {
         ];
 
         // create a job object
-        users.batchCreate({ body: { requests } });
+        users.batchCreate({ requests });
 
         // Create A Job
         const job = users
-            .batchCreate({ body: { requests: [createReq1] } }, { pollInterval: 1000 })
+            .batchCreate({ requests: [createReq1] }, { pollInterval: 1000, includeSchema: true })
             .add(createReq2, createReq3);
 
         job.execute();
@@ -172,6 +173,10 @@ describe('FullStory Users API', () => {
                         expect.objectContaining({ ...createReq3 })
                     ])
                 );
+                imported.forEach(im => {
+                    // make sure schema is included
+                    expect(im.schema).toBeDefined();
+                });
                 done();
             });
 

--- a/src/batch/index.ts
+++ b/src/batch/index.ts
@@ -27,12 +27,20 @@ export interface BatchJobOptions {
      * poll had completed.
      * If polling had hit a rate limit, exponentially increasing delays based on `retry-after` header
      * and the number of consecutive failures.
+     * Default: 2000
      */
     pollInterval?: number;
     /*
      * maxRetry: max number of API errors in a row before aborting.
+     * Default: 3.
      */
     maxRetry?: number,
+    /*
+     * includeSchema: whether to include schema in the server responses when retrieving
+     * imported items.
+     * Default: false.
+     */
+    includeSchema?: boolean,
     /*
      * TODO(sabrina): add a timeout and onTimeout to clean up everything
      * TODO(sabrina): allow custom retry policies
@@ -42,6 +50,7 @@ export interface BatchJobOptions {
 export const DefaultBatchJobOpts: Required<BatchJobOptions> = {
     pollInterval: 2000,
     maxRetry: 3,
+    includeSchema: false,
 };
 
 export interface BatchJob<REQUEST extends { requests: SINGLE_REQ[]; }, SINGLE_REQ, IMPORT, FAILURE> {

--- a/src/events.ts
+++ b/src/events.ts
@@ -26,7 +26,7 @@ interface BatchEventsApi {
     batchCreate(
         request?: CreateBatchEventsImportJobRequest | {
             /** @deprecated Set request as {@link CreateBatchEventsImportJobRequest} instead */
-            body: CreateBatchEventsImportJobRequest,
+            body?: CreateBatchEventsImportJobRequest,
             /** @deprecated Use  {@link BatchJobOptions.includeSchema} instead */
             includeSchema?: boolean,
         },

--- a/src/users.ts
+++ b/src/users.ts
@@ -35,7 +35,7 @@ interface BatchUsersApi {
     batchCreate(
         request?: CreateBatchUserImportJobRequest | {
             /** @deprecated Set request as {@link CreateBatchUserImportJobRequest} instead */
-            body: CreateBatchUserImportJobRequest,
+            body?: CreateBatchUserImportJobRequest,
             /** @deprecated Use {@link BatchJobOptions.includeSchema} instead */
             includeSchema?: boolean,
         },


### PR DESCRIPTION
- per feedback from https://fullstory.atlassian.net/browse/ECO-8823
- Just playing around with the method signature for the `batchCreate`, pushing as draft, LMKWDYT


1. BEFORE: loads of different options at different places
```
const batchJob = await events.withOptions({ integrationSource: 'test'}).batchCreate(
  { 
    body: { requests: [{ uid: 'user123' }] },
    includeSchema: true,
  },
  { maxRetry: 2 }
);
```

2. AFTER: eliminate the option in the method and allow the job creation to be:
```
const batchJob = await events
  .withOptions({ integrationSource: 'test'})
  .batchCreate(
    { requests: [{ uid: 'user123' }] },
    { maxRetry: 2, includeSchema: true }
);
```

### caveat
  -  there are some fields getting deprecate, and move to the new place,  seen in IDE:

  <img width="956" alt="Screenshot 2023-09-26 at 1 01 31 PM" src="https://github.com/fullstorydev/fullstory-node-sdk/assets/46504647/8ba8f5e5-d4fb-4e17-86c5-c9e716d3d5c1">
  <img width="1043" alt="Screenshot 2023-09-26 at 1 00 33 PM" src="https://github.com/fullstorydev/fullstory-node-sdk/assets/46504647/3fb4e79d-7034-4f6d-a7ef-7f6ab10f65e6">
  <img width="943" alt="Screenshot 2023-09-26 at 1 00 28 PM" src="https://github.com/fullstorydev/fullstory-node-sdk/assets/46504647/08c7b08d-ee55-44c9-98d9-0583860533a1">


 -  *So that both old and new signature could be supported.. but the new fields overrides the old ones:*
```
// If this happens
const batchJob = await events.withOptions({ integrationSource: 'test'}).batchCreate(
  { 
    body: { requests: [{ uid: 'user123' }] },
    includeSchema: true // this is deprecated, doesn't take effect
  },
  { maxRetry: 2, includeSchema: false} // this takes effect
);
```

- The "Batch Job Options" now are locked in to always include `includeSchema` which may or may not make sense to other types of resources in the future..