### PR TITLE
fix test match error string

### DIFF
--- a/src/http/__tests__/index.test.ts
+++ b/src/http/__tests__/index.test.ts
@@ -119,7 +119,7 @@ describe('FSHttpClient', () => {
                 expect(e).toHaveProperty('httpStatusCode', 200);
                 expect(e).toHaveProperty('fsErrorPayload', invalidRsp);
                 expect(e.cause).toHaveProperty('name', 'SyntaxError');
-                expect(e.cause).toHaveProperty('message', expect.stringMatching(new RegExp('Unexpected token \'?i\'?')));
+                expect(e.cause).toHaveProperty('message', expect.stringContaining('Unexpected token'));
             }
         }
     }, 2000);

--- a/src/http/__tests__/index.test.ts
+++ b/src/http/__tests__/index.test.ts
@@ -119,7 +119,7 @@ describe('FSHttpClient', () => {
                 expect(e).toHaveProperty('httpStatusCode', 200);
                 expect(e).toHaveProperty('fsErrorPayload', invalidRsp);
                 expect(e.cause).toHaveProperty('name', 'SyntaxError');
-                expect(e.cause).toHaveProperty('message', expect.stringMatching(new RegExp('Unexpected token . in JSON at position')));
+                expect(e.cause).toHaveProperty('message', expect.stringMatching(new RegExp('Unexpected token \'?i\'?')));
             }
         }
     }, 2000);


### PR DESCRIPTION
With the newer node version, `JSON.parse` returned a different string message: from `Unexpected token xxx in JSON at position x` to `Unexpected token 'i', "invalid js"... is not valid JSON`
Fixing the test to make it fuzzier. (It shouldn't really matter that much, as long as we assert that it's a `SyntaxError` parsing json.